### PR TITLE
docs: document graphql backfill cache flush flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ cd backend
 npm install
 npm start
 node run_graphql_backfill.js 30
+node run_graphql_backfill.js 30 --flush-cache
 node run_reaggregation.js
 node backfill_single_repo.js <repo-name>
 ```
@@ -196,6 +197,9 @@ npm run lint
 - 可通过 `STARTUP_BACKFILL_DAYS` 控制启动回填天数，默认值为 `30`
 - 默认情况下，服务启动时不会自动清空 Redis
 - 如需在启动时清空 Redis，可通过环境变量 `ENABLE_STARTUP_CACHE_FLUSH=true` 显式开启
+- 默认情况下，`backend/run_graphql_backfill.js` 在回填结束后不会自动清空 Redis
+- 如需在回填完成后清空 Redis，可显式传入 `--flush-cache`
+- 示例：`node run_graphql_backfill.js 30 --flush-cache`
 - 数据回填可能持续较长时间，取决于仓库数量与 GitHub API 限流情况
 - 在共享环境中操作缓存和回填脚本前，建议先确认影响范围
 
@@ -225,6 +229,13 @@ psql -d oss_dashboard -c "\dt contributors"
 ```bash
 cd backend
 node run_graphql_backfill.js 30
+```
+
+如需在回填结束后同步清空 Redis，可改用：
+
+```bash
+cd backend
+node run_graphql_backfill.js 30 --flush-cache
 ```
 
 ### 遇到 GitHub API 限流


### PR DESCRIPTION
Summary
  This PR updates the documentation to clarify the behavior of the GraphQL backfill script and the newly added
  cache flush options.


  What changed
   - Documented the --flush-cache flag for the run_graphql_backfill.js script.
   - Clarified that the backfill script does not automatically flush Redis by default after completion.
   - Added explicit instructions on how to manually trigger a cache flush during or after a backfill operation.
   - Updated the "Troubleshooting" section to include cache-clearing as a standard step for data visibility
     issues.


  Why
  The previous documentation didn't clearly state that backfilled data might not be immediately visible in the
  frontend due to Redis caching. By documenting the --flush-cache flag and the opt-in nature of cache clearing,
  maintainers can:
   - Ensure data consistency after running manual backfills.
   - Avoid confusion when new data doesn't appear immediately on the dashboard.
   - Safely manage cache in production/shared environments where an automatic flush might be undesirable.


  Validation
   - Verified the --flush-cache argument exists in backend/run_graphql_backfill.js.
   - Cross-referenced the documentation with the actual script logic to ensure accuracy.
   - Proofread the updated Markdown for clarity and formatting.