### PR TITLE
fix: make reaggregation cache flush opt-in

### DIFF
--- a/backend/run_reaggregation.js
+++ b/backend/run_reaggregation.js
@@ -1,9 +1,18 @@
+/**
+ * Re-aggregation Script
+ *
+ * Usage: node run_reaggregation.js [--flush-cache]
+ * Example: node run_reaggregation.js
+ * Example: node run_reaggregation.js --flush-cache
+ */
+
 // A one-time script to re-aggregate all historical data from the corrected raw snapshots.
 require('dotenv').config();
 const { Pool } = require('pg');
 const Redis = require('redis');
 
 const ORG_NAME = 'hust-open-atom-club';
+const SHOULD_FLUSH_CACHE = process.argv.includes('--flush-cache');
 
 // --- DB and Redis Connections (from index.js) ---
 const pool = new Pool({
@@ -98,14 +107,18 @@ async function runFullReaggregation(days = 30) {
         await aggregateOrganizationSnapshot(org.id, targetDate);
     }
 
-    console.log('\n--- Clearing Redis Cache ---');
-    await redisClient.connect();
-    await redisClient.flushAll();
-    console.log('✅ Redis cache cleared.');
+    if (SHOULD_FLUSH_CACHE) {
+        console.log('\n--- Clearing Redis Cache ---');
+        await redisClient.connect();
+        await redisClient.flushAll();
+        console.log('✅ Redis cache cleared.');
+        await redisClient.quit();
+    } else {
+        console.log('\nSkipping Redis cache flush. Pass --flush-cache to enable it.');
+    }
 
     console.log('\n--- [FINISH] Re-aggregation Complete ---');
     await pool.end();
-    await redisClient.quit();
 }
 
 runFullReaggregation(365).catch(console.error);


### PR DESCRIPTION
 What changed
  This PR makes Redis cache flushing in backend/run_reaggregation.js opt-in instead of running by default.

  Changes
   * updated the script usage comment to document --flush-cache
   * added a SHOULD_FLUSH_CACHE flag based on CLI arguments
   * changed the script to connect to Redis and call redisClient.flushAll() only when --flush-cache is explicitly passed
   * moved redisClient.quit() into the conditional block to ensure proper resource cleanup without throwing connection errors when Redis is skipped

  Why
  Running the re-aggregation script should not clear the entire Redis cache by default.

  Previously, executing the re-aggregation script would always connect to Redis and flush all keys at the end of the run. That introduces an unnecessary high-impact side effect,
  especially in production or shared environments where flushing all caches might cause temporary performance degradation.

  After this change:
   * node run_reaggregation.js runs the re-aggregation without connecting to or clearing Redis
   * node run_reaggregation.js --flush-cache runs the re-aggregation and explicitly clears Redis

  Validation
  Tested manually:

   * Default run
     * Command: node run_reaggregation.js
     * Re-aggregation executed normally
     * The script printed: Skipping Redis cache flush. Pass --flush-cache to enable it.
     * Script exited cleanly without Redis connection errors.
     * A Redis sentinel key remained present after execution.

   * Explicit cache flush
     * Command: node run_reaggregation.js --flush-cache
     * Re-aggregation executed normally
     * The script printed cache flush logs (--- Clearing Redis Cache ---)
     * Script exited cleanly.
     * The Redis sentinel key was removed after execution.

  Scope
  This PR intentionally only updates backend/run_reaggregation.js.

  It does not:
   * modify run_graphql_backfill.js (addressed in a separate PR)
   * change server startup behavior
   * replace flushAll() with prefix-based cache invalidation
   * change the hardcoded days argument behavior for the re-aggregation script