### PR TITLE
fix: force UTF-8 encoding for psql scripts on Windows PowerShell

### DIFF
--- a/db/contributors_schema.sql
+++ b/db/contributors_schema.sql
@@ -1,3 +1,6 @@
+\encoding UTF8
+SET client_encoding = 'UTF8';
+
 -- 贡献者追踪系统数据库表
 -- 执行: psql -d oss_dashboard -f db/contributors_schema.sql
 
@@ -81,4 +84,3 @@ COMMENT ON COLUMN contributors.github_username IS 'GitHub 用户名';
 COMMENT ON COLUMN contributors.github_id IS 'GitHub 用户 ID（数字）';
 COMMENT ON COLUMN contributors.first_seen_date IS '首次出现在系统中的日期';
 COMMENT ON COLUMN contributors.last_seen_date IS '最后一次活跃的日期';
-

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,3 +1,6 @@
+\encoding UTF8
+SET client_encoding = 'UTF8';
+
 -- Table: organizations
 -- 组织表 (现在只用于存储 hust-open-atom-club)
 CREATE TABLE organizations (

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,3 +1,6 @@
+\encoding UTF8
+SET client_encoding = 'UTF8';
+
 -- 1. Insert the single monitored organization
 INSERT INTO organizations (name) VALUES
 ('hust-open-atom-club')
@@ -117,5 +120,4 @@ INSERT INTO repositories (org_id, sig_id, name) VALUES
 -- Clean up helper functions
 DROP FUNCTION get_org_id();
 DROP FUNCTION get_sig_id(sig_name VARCHAR);
-
 


### PR DESCRIPTION
## What changed

  This PR fixes a Windows PowerShell encoding issue when running `psql -f` against the SQL files
  in `db/`.

  ### Changes
  Added the following lines to the top of these files:

  ```sql
  \encoding UTF8
  SET client_encoding = 'UTF8';

  Affected files:

  - db/schema.sql
  - db/seed.sql
  - db/contributors_schema.sql

  ## Why

  Some SQL files in db/ contain Chinese comments or text.

  On Windows PowerShell, psql -f may use GBK as the client encoding by default, which can cause
  execution failures when reading UTF-8 SQL files.

  that UTF-8 content is handled correctly.

  ## Scope

  This PR only updates SQL script encoding declarations in:

  - db/schema.sql
  - db/seed.sql
  - db/contributors_schema.sql