### PR TITLE
Feat/date range backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ npm start
 
 需要在 `backend/.env` 中配置数据库、Redis 与 GitHub Token。
 
+默认情况下，后端服务启动时不会自动清空 Redis，也不会自动执行历史数据回填。
+
+如需启用这些启动行为，可在 `backend/.env` 中显式配置：
+
+```env
+ENABLE_STARTUP_CACHE_FLUSH=true
+ENABLE_STARTUP_BACKFILL=true
+STARTUP_BACKFILL_DAYS=30
+```
 ### 3. 启动前端
 
 ```bash
@@ -188,6 +197,11 @@ npm run lint
 
 注意：
 
+- 默认情况下，服务启动时不会自动触发历史数据回填
+- 如需在启动时自动回填，可通过环境变量 `ENABLE_STARTUP_BACKFILL=true` 显式开启
+- 可通过 `STARTUP_BACKFILL_DAYS` 控制启动回填天数，默认值为 `30`
+- 默认情况下，服务启动时不会自动清空 Redis
+- 如需在启动时清空 Redis，可通过环境变量 `ENABLE_STARTUP_CACHE_FLUSH=true` 显式开启
 - 默认情况下，`backend/run_graphql_backfill.js` 在回填结束后不会自动清空 Redis
 - 如需在回填完成后清空 Redis，可显式传入 `--flush-cache`
 - 示例：`node run_graphql_backfill.js 30 --flush-cache`

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ oss-dashboard/
 ├── backend/                    # Node.js/Express 后端服务
 │   ├── server.js               # 主服务器文件
 │   ├── run_graphql_backfill.js # 数据回填脚本
+│   ├── backfill_date_range.js  # 按单日/日期范围定点回填脚本
 │   ├── run_reaggregation.js    # 重聚合脚本
 │   └── .env.example            # 环境变量示例
 ├── frontend/                   # React/Vite 前端应用
@@ -102,16 +103,6 @@ npm start
 
 需要在 `backend/.env` 中配置数据库、Redis 与 GitHub Token。
 
-默认情况下，后端服务启动时不会自动清空 Redis，也不会自动执行历史数据回填。
-
-如需启用这些启动行为，可在 `backend/.env` 中显式配置：
-
-```env
-ENABLE_STARTUP_CACHE_FLUSH=true
-ENABLE_STARTUP_BACKFILL=true
-STARTUP_BACKFILL_DAYS=30
-```
-
 ### 3. 启动前端
 
 ```bash
@@ -132,7 +123,11 @@ npm install
 npm start
 node run_graphql_backfill.js 30
 node run_graphql_backfill.js 30 --flush-cache
+node backfill_date_range.js --date 2026-03-12
+node backfill_date_range.js --start-date 2026-03-12 --end-date 2026-03-14
+node backfill_date_range.js --date 2026-03-31 --reset-existing --flush-cache
 node run_reaggregation.js
+node run_reaggregation.js --flush-cache
 node backfill_single_repo.js <repo-name>
 ```
 
@@ -188,18 +183,21 @@ npm run lint
 
 - **自动更新**：后端服务默认每 6 小时自动采集一次新数据
 - **手动回填**：使用 `backend/run_graphql_backfill.js`
+- **定点回填**：使用 `backend/backfill_date_range.js` 按单天或自定义日期范围修复数据
 - **重聚合**：使用 `backend/run_reaggregation.js`
 
 注意：
 
-- 默认情况下，服务启动时不会自动触发历史数据回填
-- 如需在启动时自动回填，可通过环境变量 `ENABLE_STARTUP_BACKFILL=true` 显式开启
-- 可通过 `STARTUP_BACKFILL_DAYS` 控制启动回填天数，默认值为 `30`
-- 默认情况下，服务启动时不会自动清空 Redis
-- 如需在启动时清空 Redis，可通过环境变量 `ENABLE_STARTUP_CACHE_FLUSH=true` 显式开启
 - 默认情况下，`backend/run_graphql_backfill.js` 在回填结束后不会自动清空 Redis
 - 如需在回填完成后清空 Redis，可显式传入 `--flush-cache`
 - 示例：`node run_graphql_backfill.js 30 --flush-cache`
+- `backend/backfill_date_range.js` 支持 `--date YYYY-MM-DD` 和 `--start-date YYYY-MM-DD --end-date YYYY-MM-DD`
+- 如需在定点回填前先删除目标日期范围内已有数据，可追加 `--reset-existing`
+- 如需在定点回填完成后同步清空 Redis，可追加 `--flush-cache`
+- 示例：`node backfill_date_range.js --date 2026-03-31 --reset-existing --flush-cache`
+- 默认情况下，`backend/run_reaggregation.js` 在重聚合结束后不会自动清空 Redis
+- 如需在重聚合完成后清空 Redis，可显式传入 `--flush-cache`
+- 示例：`node run_reaggregation.js --flush-cache`
 - 数据回填可能持续较长时间，取决于仓库数量与 GitHub API 限流情况
 - 在共享环境中操作缓存和回填脚本前，建议先确认影响范围
 
@@ -238,9 +236,18 @@ cd backend
 node run_graphql_backfill.js 30 --flush-cache
 ```
 
+如果只有少数日期异常，优先使用定点回填脚本：
+
+```bash
+cd backend
+node backfill_date_range.js --date 2026-03-12 --reset-existing
+node backfill_date_range.js --start-date 2026-03-12 --end-date 2026-03-14 --reset-existing --flush-cache
+```
+
 ### 遇到 GitHub API 限流
 
 - 等待额度恢复后重试
+- 如果只需要修复少数异常日期，优先使用 `backfill_date_range.js` 缩小回填范围
 - 适当减少回填天数，例如：
 
 ```bash

--- a/backend/backfill_date_range.js
+++ b/backend/backfill_date_range.js
@@ -1,0 +1,193 @@
+/**
+ * Date Range Backfill Script
+ *
+ * 用法:
+ *   node backfill_date_range.js --date YYYY-MM-DD
+ *   node backfill_date_range.js --start-date YYYY-MM-DD --end-date YYYY-MM-DD
+ *
+ * 可选参数:
+ *   --flush-cache    回填结束后清空 Redis 缓存
+ *   --reset-existing 先删除目标日期范围内的旧数据，再执行回填
+ *   --help           显示帮助信息
+ */
+
+require('dotenv').config();
+const { Pool } = require('pg');
+const path = require('path');
+const {
+    runGraphQLBackfillForRange,
+    formatDate,
+    getScopedProgressFile,
+} = require('./run_graphql_backfill');
+
+const pool = new Pool({
+    user: process.env.DB_USER,
+    host: process.env.DB_HOST,
+    database: process.env.DB_NAME,
+    password: process.env.DB_PASSWORD,
+    port: process.env.DB_PORT,
+});
+
+function printUsage() {
+    console.log(`
+Date range backfill usage:
+
+  node backfill_date_range.js --date 2026-03-12
+  node backfill_date_range.js --start-date 2026-03-12 --end-date 2026-03-14
+  node backfill_date_range.js --date 2026-03-12 --flush-cache
+  node backfill_date_range.js --start-date 2026-03-12 --end-date 2026-03-14 --reset-existing
+
+Options:
+  --date         Backfill a single day
+  --start-date   Range start date in YYYY-MM-DD
+  --end-date     Range end date in YYYY-MM-DD
+  --flush-cache  Flush Redis after the backfill finishes
+  --reset-existing
+                 Delete existing rows in the target date range before backfill
+  --help         Show this help message
+`);
+}
+
+function parseDateLiteral(value, flagName) {
+    if (!value) {
+        throw new Error(`${flagName} requires a value in YYYY-MM-DD format.`);
+    }
+
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        throw new Error(`${flagName} must use YYYY-MM-DD format.`);
+    }
+
+    const [year, month, day] = value.split('-').map(Number);
+    const parsedDate = new Date(year, month - 1, day);
+
+    if (formatDate(parsedDate) !== value) {
+        throw new Error(`${flagName} is not a valid calendar date.`);
+    }
+
+    return parsedDate;
+}
+
+async function resetExistingData(startDate, endDate) {
+    const startDateStr = formatDate(startDate);
+    const endDateStr = formatDate(endDate);
+    const client = await pool.connect();
+
+    try {
+        await client.query('BEGIN');
+
+        const deleteTargets = [
+            'contributor_repo_activities',
+            'contributor_daily_activities',
+            'repo_snapshots',
+            'sig_snapshots',
+            'activity_snapshots',
+        ];
+
+        for (const tableName of deleteTargets) {
+            const result = await client.query(
+                `DELETE FROM ${tableName} WHERE snapshot_date BETWEEN $1 AND $2`,
+                [startDateStr, endDateStr]
+            );
+            console.log(`Reset ${tableName}: deleted ${result.rowCount} rows for ${startDateStr} to ${endDateStr}`);
+        }
+
+        await client.query('COMMIT');
+    } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+    } finally {
+        client.release();
+    }
+}
+
+async function main() {
+    const args = process.argv.slice(2);
+    let singleDateArg = null;
+    let startDateArg = null;
+    let endDateArg = null;
+    let flushCache = false;
+    let resetExisting = false;
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+
+        if (arg === '--help') {
+            printUsage();
+            return;
+        }
+
+        if (arg === '--flush-cache') {
+            flushCache = true;
+            continue;
+        }
+
+        if (arg === '--reset-existing') {
+            resetExisting = true;
+            continue;
+        }
+
+        if (arg === '--date') {
+            singleDateArg = args[++i];
+            continue;
+        }
+
+        if (arg === '--start-date') {
+            startDateArg = args[++i];
+            continue;
+        }
+
+        if (arg === '--end-date') {
+            endDateArg = args[++i];
+            continue;
+        }
+
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+
+    if (singleDateArg && (startDateArg || endDateArg)) {
+        throw new Error('Use either --date or --start-date/--end-date, not both.');
+    }
+
+    if (!singleDateArg && (!startDateArg || !endDateArg)) {
+        throw new Error('You must provide either --date or both --start-date and --end-date.');
+    }
+
+    const startDate = singleDateArg
+        ? parseDateLiteral(singleDateArg, '--date')
+        : parseDateLiteral(startDateArg, '--start-date');
+    const endDate = singleDateArg
+        ? parseDateLiteral(singleDateArg, '--date')
+        : parseDateLiteral(endDateArg, '--end-date');
+
+    if (startDate > endDate) {
+        throw new Error('--start-date cannot be later than --end-date.');
+    }
+
+    const progressFile = getScopedProgressFile(startDate, endDate);
+    const description = startDate.getTime() === endDate.getTime()
+        ? `date ${formatDate(startDate)}`
+        : `date range ${formatDate(startDate)} to ${formatDate(endDate)}`;
+
+    console.log(`Using progress file: ${path.basename(progressFile)}`);
+
+    try {
+        if (resetExisting) {
+            await resetExistingData(startDate, endDate);
+        }
+
+        await runGraphQLBackfillForRange({
+            startDate,
+            endDate,
+            progressFile,
+            description,
+            flushCache,
+        });
+    } finally {
+        await pool.end();
+    }
+}
+
+main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+});

--- a/backend/run_graphql_backfill.js
+++ b/backend/run_graphql_backfill.js
@@ -4,8 +4,9 @@
  * 使用 GraphQL API 高效回填历史数据。
  * 相比 REST API 可以提升约 100 倍性能。
  * 
- * 用法: node run_graphql_backfill.js [days]
+ * 用法: node run_graphql_backfill.js [days] [--flush-cache]
  * 例如: node run_graphql_backfill.js 365
+ * 例如: node run_graphql_backfill.js 30 --flush-cache
  */
 
 require('dotenv').config();
@@ -986,6 +987,8 @@ async function runGraphQLBackfillForRange({ startDate, endDate, progressFile = P
             console.log('--- Clearing Redis Cache ---');
             await redisClient.flushAll();
             console.log('✅ Redis cache cleared.');
+        } else {
+            console.log('Skipping Redis cache flush. Pass --flush-cache to enable it.');
         }
 
         // Display contributor statistics
@@ -1044,14 +1047,18 @@ async function runGraphQLBackfill(days = 30, options = {}) {
         endDate,
         progressFile: options.progressFile || PROGRESS_FILE,
         description: `${days} days of data`,
-        flushCache: options.flushCache !== undefined ? options.flushCache : true,
+        flushCache: options.flushCache !== undefined ? options.flushCache : false,
     });
 }
 
 // --- Run ---
 if (require.main === module) {
-    const days = parseInt(process.argv[2], 10) || 730;
-    runGraphQLBackfill(days).catch((error) => {
+    const args = process.argv.slice(2);
+    const flushCache = args.includes('--flush-cache');
+    const daysArg = args.find((arg) => /^\d+$/.test(arg));
+    const days = daysArg ? parseInt(daysArg, 10) : 730;
+
+    runGraphQLBackfill(days, { flushCache }).catch((error) => {
         console.error(error);
         process.exitCode = 1;
     });

--- a/backend/run_graphql_backfill.js
+++ b/backend/run_graphql_backfill.js
@@ -4,9 +4,8 @@
  * 使用 GraphQL API 高效回填历史数据。
  * 相比 REST API 可以提升约 100 倍性能。
  * 
- * 用法: node run_graphql_backfill.js [days] [--flush-cache]
+ * 用法: node run_graphql_backfill.js [days]
  * 例如: node run_graphql_backfill.js 365
- * 例如: node run_graphql_backfill.js 30 --flush-cache
  */
 
 require('dotenv').config();
@@ -20,7 +19,6 @@ const path = require('path');
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const ORG_NAME = 'hust-open-atom-club';
 const PROGRESS_FILE = path.join(__dirname, 'backfill_progress.json');
-const SHOULD_FLUSH_CACHE = process.argv.includes('--flush-cache');
 
 // --- Optimized Concurrency Settings ---
 const GRAPHQL_CONCURRENCY_LIMIT = 5;  // GraphQL requests (rate limited)
@@ -55,6 +53,34 @@ const formatDate = (date) => {
     const day = date.getDate().toString().padStart(2, '0');
     return `${year}-${month}-${day}`;
 };
+
+function normalizeDate(date) {
+    const normalized = new Date(date);
+    normalized.setHours(0, 0, 0, 0);
+    return normalized;
+}
+
+function buildDateList(startDate, endDate) {
+    const allDates = [];
+    const currentDate = normalizeDate(startDate);
+    const lastDate = normalizeDate(endDate);
+
+    while (currentDate <= lastDate) {
+        allDates.push(new Date(currentDate));
+        currentDate.setDate(currentDate.getDate() + 1);
+    }
+
+    return allDates;
+}
+
+function getScopedProgressFile(startDate, endDate) {
+    const startDateStr = formatDate(startDate);
+    const endDateStr = formatDate(endDate);
+    const fileName = startDateStr === endDateStr
+        ? `backfill_progress_${startDateStr}.json`
+        : `backfill_progress_${startDateStr}_${endDateStr}.json`;
+    return path.join(__dirname, fileName);
+}
 
 // --- GraphQL API with Adaptive Rate Limiting ---
 async function githubGraphQL(query, variables = {}) {
@@ -724,22 +750,22 @@ async function runPromisesWithConcurrency(tasks, concurrency) {
 }
 
 // --- Progress Checkpoint Functions ---
-async function loadProgress() {
+async function loadProgress(progressFile = PROGRESS_FILE) {
     try {
-        const data = await fs.readFile(PROGRESS_FILE, 'utf8');
+        const data = await fs.readFile(progressFile, 'utf8');
         return JSON.parse(data);
     } catch {
         return { completedRepos: {}, gitCompleted: false, graphqlCompleted: false };
     }
 }
 
-async function saveProgress(progress) {
-    await fs.writeFile(PROGRESS_FILE, JSON.stringify(progress, null, 2));
+async function saveProgress(progress, progressFile = PROGRESS_FILE) {
+    await fs.writeFile(progressFile, JSON.stringify(progress, null, 2));
 }
 
-async function clearProgress() {
+async function clearProgress(progressFile = PROGRESS_FILE) {
     try {
-        await fs.unlink(PROGRESS_FILE);
+        await fs.unlink(progressFile);
     } catch {
         // File doesn't exist, that's fine
     }
@@ -761,17 +787,33 @@ function formatElapsedTime(startTime) {
 
 
 // --- Main Backfill Function (Optimized) ---
-async function runGraphQLBackfill(days = 30) {
+async function runGraphQLBackfillForRange({ startDate, endDate, progressFile = PROGRESS_FILE, description, flushCache = false }) {
+    const normalizedStartDate = normalizeDate(startDate);
+    const normalizedEndDate = normalizeDate(endDate);
+
+    if (Number.isNaN(normalizedStartDate.getTime()) || Number.isNaN(normalizedEndDate.getTime())) {
+        throw new Error('Invalid date range for GraphQL backfill.');
+    }
+
+    if (normalizedStartDate > normalizedEndDate) {
+        throw new Error('startDate cannot be later than endDate.');
+    }
+
+    const allDates = buildDateList(normalizedStartDate, normalizedEndDate);
+    const runDescription = description || `${formatDate(normalizedStartDate)} to ${formatDate(normalizedEndDate)}`;
+
     console.log(`\n${'='.repeat(60)}`);
     console.log(`--- Starting Optimized GraphQL Backfill Job ---`);
-    console.log(`--- Processing ${days} days of data ---`);
+    console.log(`--- Processing ${runDescription} ---`);
     console.log(`${'='.repeat(60)}\n`);
 
     const startTime = Date.now();
-    let progress = await loadProgress();
+    let progress = await loadProgress(progressFile);
 
     try {
-        await redisClient.connect();
+        if (flushCache) {
+            await redisClient.connect();
+        }
 
         const orgsResult = await pool.query("SELECT id FROM organizations WHERE name = $1", [ORG_NAME]);
         const org = orgsResult.rows[0];
@@ -791,29 +833,13 @@ async function runGraphQLBackfill(days = 30) {
         const sigsResult = await pool.query('SELECT id, name FROM special_interest_groups WHERE org_id = $1', [org.id]);
         const sigs = sigsResult.rows;
 
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-
-        const startDate = new Date(today);
-        startDate.setDate(today.getDate() - days);
-
-        const endDate = new Date(today);
-        endDate.setDate(today.getDate() - 1);
-
-        console.log(`📅 Date range: ${formatDate(startDate)} to ${formatDate(endDate)}`);
+        console.log(`📅 Date range: ${formatDate(normalizedStartDate)} to ${formatDate(normalizedEndDate)}`);
         console.log(`📦 Repositories: ${repositories.length}`);
         console.log(`🏷️  SIGs: ${sigs.length}`);
+        console.log(`🗂️  Progress file: ${path.basename(progressFile)}`);
         console.log(`⚡ Commit Concurrency: ${COMMIT_CONCURRENCY_LIMIT}`);
         console.log(`⚡ GraphQL Concurrency: ${GRAPHQL_CONCURRENCY_LIMIT}`);
         console.log(`⏱️  Base delay: ${BASE_DELAY_MS}ms\n`);
-
-        // Build list of all dates
-        const allDates = [];
-        for (let i = days; i >= 1; i--) {
-            const targetDate = new Date(today);
-            targetDate.setDate(today.getDate() - i);
-            allDates.push(targetDate);
-        }
 
         // === PHASE 1 & 2: Run Git and GraphQL in parallel ===
         console.log('=== PHASE 1 & 2: Git + GraphQL (Parallel) ===\n');
@@ -847,7 +873,7 @@ async function runGraphQLBackfill(days = 30) {
             }
             graphqlTasks.push(async () => {
                 try {
-                    const { statsMap, contributorDetailsMap } = await fetchRepoStatsViaGraphQL(repo.name, startDate, endDate);
+                    const { statsMap, contributorDetailsMap } = await fetchRepoStatsViaGraphQL(repo.name, normalizedStartDate, normalizedEndDate);
 
                     for (const [dateStr, stats] of statsMap) {
                         const contributorDetails = contributorDetailsMap.has(dateStr)
@@ -857,7 +883,7 @@ async function runGraphQLBackfill(days = 30) {
                     }
 
                     progress.completedRepos[taskKey] = true;
-                    await saveProgress(progress);
+                    await saveProgress(progress, progressFile);
                     console.log(`[GraphQL] ${repo.name}: ✅ ${statsMap.size} days (${formatElapsedTime(startTime)}, Rate limit: ${rateLimitRemaining})`);
                 } catch (error) {
                     console.error(`[GraphQL] ${repo.name}: ❌ ${error.message}`);
@@ -876,7 +902,7 @@ async function runGraphQLBackfill(days = 30) {
                 for (let i = 0; i < gitTasks.length; i += batchSize) {
                     const batch = gitTasks.slice(i, i + batchSize);
                     await runPromisesWithConcurrency(batch, COMMIT_CONCURRENCY_LIMIT);
-                    await saveProgress(progress);
+                    await saveProgress(progress, progressFile);
                     const pct = Math.round(((i + batch.length) / gitTasks.length) * 100);
                     console.log(`[Git] Progress: ${pct}% (${formatElapsedTime(startTime)})`);
                 }
@@ -956,12 +982,10 @@ async function runGraphQLBackfill(days = 30) {
 
         console.log('=== PHASE 3 Complete ===\n');
 
-        if (SHOULD_FLUSH_CACHE) {
+        if (flushCache) {
             console.log('--- Clearing Redis Cache ---');
             await redisClient.flushAll();
             console.log('✅ Redis cache cleared.');
-        } else {
-            console.log('Skipping Redis cache flush. Pass --flush-cache to enable it.');
         }
 
         // Display contributor statistics
@@ -975,7 +999,7 @@ async function runGraphQLBackfill(days = 30) {
                     SUM(cda.prs_opened + cda.prs_closed + cda.issues_opened + cda.issues_closed) as total_activities
                 FROM contributors c
                 LEFT JOIN contributor_daily_activities cda ON c.id = cda.contributor_id AND cda.snapshot_date >= $1
-            `, [formatDate(startDate)]);
+            `, [formatDate(normalizedStartDate)]);
 
             const cStats = contributorStatsResult.rows[0];
             console.log(`  - 总贡献者数: ${cStats.total_contributors || 0}`);
@@ -988,7 +1012,7 @@ async function runGraphQLBackfill(days = 30) {
         console.log('='.repeat(30) + '\n');
 
         // Clear progress file on success
-        await clearProgress();
+        await clearProgress(progressFile);
 
         console.log(`\n${'='.repeat(60)}`);
         console.log(`--- GraphQL Backfill Job Finished Successfully ---`);
@@ -1001,10 +1025,41 @@ async function runGraphQLBackfill(days = 30) {
         console.log('Progress saved. Run again to resume.');
     } finally {
         await pool.end();
-        await redisClient.quit();
+        if (redisClient.isOpen) {
+            await redisClient.quit();
+        }
     }
 }
 
+async function runGraphQLBackfill(days = 30, options = {}) {
+    const today = normalizeDate(new Date());
+    const startDate = new Date(today);
+    startDate.setDate(today.getDate() - days);
+
+    const endDate = new Date(today);
+    endDate.setDate(today.getDate() - 1);
+
+    return runGraphQLBackfillForRange({
+        startDate,
+        endDate,
+        progressFile: options.progressFile || PROGRESS_FILE,
+        description: `${days} days of data`,
+        flushCache: options.flushCache !== undefined ? options.flushCache : true,
+    });
+}
+
 // --- Run ---
-const days = parseInt(process.argv[2], 10) || 730;
-runGraphQLBackfill(days);
+if (require.main === module) {
+    const days = parseInt(process.argv[2], 10) || 730;
+    runGraphQLBackfill(days).catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    });
+}
+
+module.exports = {
+    runGraphQLBackfill,
+    runGraphQLBackfillForRange,
+    formatDate,
+    getScopedProgressFile,
+};


### PR DESCRIPTION
## Summary

  This PR adds targeted backfill support for a single day or a custom date range, so data fixes no longer require re-running the full historical GraphQL backfill.

  ## Changes

  - add `backend/backfill_date_range.js` for single-day and date-range backfill
  - reuse GraphQL backfill logic through exported range-based helpers
  - add scoped progress files for different backfill date ranges
  - support optional `--reset-existing` to delete existing rows in the target range before backfill
  - support optional `--flush-cache` after targeted backfill completes
  - update `README.md` with usage examples and operational guidance
  - document explicit cache flush behavior for `run_reaggregation.js`

  ## Usage

  ```bash
  node backfill_date_range.js --date 2026-03-12
  node backfill_date_range.js --start-date 2026-03-12 --end-date 2026-03-14
  node backfill_date_range.js --date 2026-03-31 --reset-existing --flush-cache
  ```

  ## Why

  Previously, fixing data issues for only a few abnormal dates required running a broader backfill job, which was slower and increased GitHub API pressure.
  This change makes targeted repair safer and more efficient.

  - --date and --start-date/--end-date are mutually exclusive
  - --reset-existing is optional and should be used carefully in shared environments
  - progress is tracked with date-scoped progress files to avoid conflicts across runs