### PR TITLE
fix: prevent GitHub PAT exposure in git operations

### DIFF
--- a/backend/backfill_single_repo.js
+++ b/backend/backfill_single_repo.js
@@ -2,12 +2,14 @@
 require('dotenv').config();
 const { Pool } = require('pg');
 // 复制所有需要的工具函数
-const { exec } = require('child_process');
-const { promisify } = require('util');
-const execPromise = promisify(exec);
 const fs = require('fs/promises');
 const path = require('path');
 const axios = require('axios');
+const {
+    cloneOrPullRepoSecure,
+    redactSecrets,
+    runGit,
+} = require('./git_secure');
 
 const ORG_NAME = 'hust-open-atom-club';
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
@@ -139,61 +141,19 @@ async function githubRest(endpoint, params = {}) {
  */
 async function cloneOrPullRepo(repoName) {
     const repoPath = path.join(REPO_STORAGE_PATH, repoName);
-    const repoUrl = `https://${GITHUB_TOKEN}@github.com/${ORG_NAME}/${repoName}.git`;
 
     try {
-        // 检查仓库目录是否存在
-        const repoExists = await fs.access(repoPath).then(() => true).catch(() => false);
-
-        if (repoExists) {
-            // 仓库存在，尝试 pull
-            try {
-                // 先检查是否是有效的 git 仓库
-                await execPromise(`git -C "${repoPath}" rev-parse --git-dir`, { timeout: 5000 });
-
-                // 尝试 pull，如果失败可能是空仓库或分支问题
-                try {
-                    await execPromise(`git -C "${repoPath}" pull --ff-only`, { timeout: 60000 });
-                } catch (pullError) {
-                    // 如果 pull 失败，检查是否是空仓库或分支问题
-                    const branchCheck = await execPromise(`git -C "${repoPath}" branch -r`, { timeout: 5000 }).catch(() => null);
-                    if (!branchCheck || !branchCheck.stdout.trim()) {
-                        console.warn(`${repoName}: 仓库为空或没有远程分支，跳过`);
-                        // 返回路径但标记为无效
-                        return repoPath;
-                    }
-                    // 尝试 fetch 然后 pull
-                    console.warn(`${repoName}: Pull failed, trying fetch...`);
-                    await execPromise(`git -C "${repoPath}" fetch origin`, { timeout: 60000 });
-                    await execPromise(`git -C "${repoPath}" pull --ff-only`, { timeout: 60000 });
-                }
-            } catch (gitError) {
-                // 如果不是有效的 git 仓库，删除并重新克隆
-                console.warn(`${repoName}: not availabe, trying re-clone...`);
-                await fs.rm(repoPath, { recursive: true, force: true });
-                await execPromise(`git clone ${repoUrl} ${repoPath}`, { timeout: 120000 });
-            }
-        } else {
-            // 仓库不存在，克隆
-            console.log(`Cloning repo: ${repoName}`);
-            try {
-                await execPromise(`git clone ${repoUrl} ${repoPath}`, { timeout: 120000 });
-            } catch (cloneError) {
-                // 克隆失败可能是仓库不存在或为空
-                console.error(`${repoName}: cloning failed: ${cloneError.message}`);
-                // 创建一个空目录，后续 git log 会返回空结果
-                await fs.mkdir(repoPath, { recursive: true });
-                return repoPath;
-            }
-        }
+        return await cloneOrPullRepoSecure({
+            repoName,
+            repoStoragePath: REPO_STORAGE_PATH,
+            orgName: ORG_NAME,
+        });
     } catch (error) {
-        console.error(`${repoName}: operate failed: ${error.message}`);
+        console.error(`${repoName}: operate failed\n${redactSecrets(error.message)}`);
         // 确保目录存在，即使 git 操作失败
         await fs.mkdir(repoPath, { recursive: true }).catch(() => { });
         return repoPath;
     }
-
-    return repoPath;
 }
 
 /**
@@ -213,10 +173,16 @@ async function getCommitStats(repoName, targetDate) {
     const endISO = formatDate(endDate);
     const startISO = formatDate(startDate);
 
-    const command = `git -C "${repoPath}" log --since="${startISO}" --until="${endISO}" --pretty=format:"COMMIT_SEPARATOR%an" --numstat`;
-
     try {
-        const { stdout } = await execPromise(command, { maxBuffer: 1024 * 1024 * 10 });
+        const { stdout } = await runGit([
+            '-C',
+            repoPath,
+            'log',
+            `--since=${startISO}`,
+            `--until=${endISO}`,
+            '--pretty=format:COMMIT_SEPARATOR%an',
+            '--numstat',
+        ], { maxBuffer: 1024 * 1024 * 10 });
         if (!stdout.trim()) {
             return { new_commits: 0, lines_added: 0, lines_deleted: 0, committers: new Set() };
         }
@@ -271,7 +237,7 @@ async function getCommitStats(repoName, targetDate) {
         };
 
     } catch (error) {
-        console.error(`Git command failed for ${repoName}:`, error.message);
+        console.error(`Git command failed for ${repoName}\n${redactSecrets(error.message)}`);
         return { new_commits: 0, lines_added: 0, lines_deleted: 0, committers: new Set() };
     }
 }

--- a/backend/fix_git_stats.js
+++ b/backend/fix_git_stats.js
@@ -1,9 +1,11 @@
 // A one-time script to correct historical git stats without re-running API calls.
-const { exec } = require('child_process');
-const { promisify } = require('util');
-const execPromise = promisify(exec);
 const fs = require('fs/promises');
 const path = require('path');
+const {
+    cloneOrPullRepoSecure,
+    redactSecrets,
+    runGit,
+} = require('./git_secure');
 
 require('dotenv').config();
 const { Pool } = require('pg');
@@ -35,21 +37,19 @@ const formatDate = (date) => {
 };
 
 async function cloneOrPullRepo(repoName) {
-    // 这个函数直接从 index.js 复制过来，无需修改
     const repoPath = path.join(REPO_STORAGE_PATH, repoName);
-    const repoUrl = `https://${process.env.GITHUB_TOKEN}@github.com/${ORG_NAME}/${repoName}.git`;
+
     try {
-        const repoExists = await fs.access(repoPath).then(() => true).catch(() => false);
-        if (repoExists) {
-            await execPromise(`git -C "${repoPath}" pull --ff-only`, { timeout: 60000 });
-        } else {
-            await execPromise(`git clone ${repoUrl} ${repoPath}`, { timeout: 120000 });
-        }
+        return await cloneOrPullRepoSecure({
+            repoName,
+            repoStoragePath: REPO_STORAGE_PATH,
+            orgName: ORG_NAME,
+        });
     } catch (error) {
-        console.error(`${repoName}: operate failed: ${error.message}`);
+        console.error(`${repoName}: operate failed\n${redactSecrets(error.message)}`);
         await fs.mkdir(repoPath, { recursive: true }).catch(() => {});
+        return repoPath;
     }
-    return repoPath;
 }
 
 /**
@@ -66,9 +66,16 @@ async function getCommitStats(repoName, targetDate) {
     endDate.setHours(0, 0, 0, 0);
     const endISO = formatDate(endDate);
     const startISO = formatDate(startDate);
-    const command = `git -C "${repoPath}" log --since="${startISO}" --until="${endISO}" --pretty=format:"COMMIT_SEPARATOR%an" --numstat`;
     try {
-        const { stdout } = await execPromise(command, { maxBuffer: 1024 * 1024 * 10 });
+        const { stdout } = await runGit([
+            '-C',
+            repoPath,
+            'log',
+            `--since=${startISO}`,
+            `--until=${endISO}`,
+            '--pretty=format:COMMIT_SEPARATOR%an',
+            '--numstat',
+        ], { maxBuffer: 1024 * 1024 * 10 });
         if (!stdout.trim()) {
             return { new_commits: 0, lines_added: 0, lines_deleted: 0 };
         }
@@ -95,7 +102,7 @@ async function getCommitStats(repoName, targetDate) {
         }
         return { new_commits: newCommits, lines_added: linesAdded, lines_deleted: linesDeleted };
     } catch (error) {
-        console.error(`Git command failed for ${repoName}:`, error.message);
+        console.error(`Git command failed for ${repoName}\n${redactSecrets(error.message)}`);
         return { new_commits: 0, lines_added: 0, lines_deleted: 0 };
     }
 }

--- a/backend/git_secure.js
+++ b/backend/git_secure.js
@@ -1,0 +1,151 @@
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const fs = require('fs/promises');
+const path = require('path');
+
+const execFilePromise = promisify(execFile);
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function redactSecrets(input) {
+    if (input === undefined || input === null) {
+        return input;
+    }
+
+    let text = String(input);
+    const token = process.env.GITHUB_TOKEN;
+
+    if (token) {
+        text = text.replace(new RegExp(escapeRegExp(token), 'g'), '[REDACTED_GITHUB_TOKEN]');
+    }
+
+    return text
+        .replace(/https:\/\/[^@\s]+@github\.com/gi, 'https://[REDACTED]@github.com')
+        .replace(/(Authorization:\s*Basic\s+)[A-Za-z0-9+/=]+/gi, '$1[REDACTED]')
+        .replace(/(AUTHORIZATION:\s*basic\s+)[A-Za-z0-9+/=]+/gi, '$1[REDACTED]');
+}
+
+function buildRepoUrl(orgName, repoName) {
+    return `https://github.com/${orgName}/${repoName}.git`;
+}
+
+function buildGitEnv() {
+    const token = process.env.GITHUB_TOKEN;
+
+    if (!token) {
+        throw new Error('GITHUB_TOKEN is not set in environment variables.');
+    }
+
+    const basicAuth = Buffer.from(`x-access-token:${token}`, 'utf8').toString('base64');
+
+    return {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: '0',
+        GIT_CONFIG_COUNT: '2',
+        GIT_CONFIG_KEY_0: 'credential.helper',
+        GIT_CONFIG_VALUE_0: '',
+        GIT_CONFIG_KEY_1: 'http.https://github.com/.extraheader',
+        GIT_CONFIG_VALUE_1: `Authorization: Basic ${basicAuth}`,
+    };
+}
+
+function renderGitArgs(args) {
+    return args.map((arg) => (/\s/.test(arg) ? `"${arg}"` : arg)).join(' ');
+}
+
+async function runGit(args, options = {}) {
+    try {
+        return await execFilePromise('git', args, {
+            env: buildGitEnv(),
+            timeout: options.timeout,
+            cwd: options.cwd,
+            maxBuffer: options.maxBuffer || 1024 * 1024 * 10,
+            windowsHide: true,
+        });
+    } catch (error) {
+        const stdout = redactSecrets(error.stdout || '');
+        const stderr = redactSecrets(error.stderr || '');
+        const sanitized = new Error(
+            [
+                `Git command failed: git ${renderGitArgs(args)}`,
+                stderr || stdout || redactSecrets(error.message),
+            ].filter(Boolean).join('\n')
+        );
+
+        sanitized.code = error.code;
+        sanitized.stdout = stdout;
+        sanitized.stderr = stderr;
+        throw sanitized;
+    }
+}
+
+async function ensureCleanOrigin(repoPath, repoUrl) {
+    const current = await runGit(['-C', repoPath, 'remote', 'get-url', 'origin'], {
+        timeout: 5000,
+    }).catch(() => null);
+
+    if (current?.stdout?.trim() === repoUrl) {
+        return;
+    }
+
+    const remotes = await runGit(['-C', repoPath, 'remote'], {
+        timeout: 5000,
+    }).catch(() => null);
+
+    const hasOrigin = remotes
+        ? remotes.stdout.split(/\r?\n/).some((line) => line.trim() === 'origin')
+        : false;
+
+    const args = hasOrigin
+        ? ['-C', repoPath, 'remote', 'set-url', 'origin', repoUrl]
+        : ['-C', repoPath, 'remote', 'add', 'origin', repoUrl];
+
+    await runGit(args, { timeout: 5000 });
+}
+
+async function cloneOrPullRepoSecure({ repoName, repoStoragePath, orgName }) {
+    const repoPath = path.join(repoStoragePath, repoName);
+    const repoUrl = buildRepoUrl(orgName, repoName);
+    const repoExists = await fs.access(repoPath).then(() => true).catch(() => false);
+
+    if (!repoExists) {
+        await runGit(['clone', repoUrl, repoPath], { timeout: 120000 });
+        return repoPath;
+    }
+
+    try {
+        await runGit(['-C', repoPath, 'rev-parse', '--git-dir'], { timeout: 5000 });
+        await ensureCleanOrigin(repoPath, repoUrl);
+
+        try {
+            await runGit(['-C', repoPath, 'pull', '--ff-only'], { timeout: 60000 });
+        } catch (pullError) {
+            const branchCheck = await runGit(['-C', repoPath, 'branch', '-r'], {
+                timeout: 5000,
+            }).catch(() => null);
+
+            if (!branchCheck || !branchCheck.stdout.trim()) {
+                return repoPath;
+            }
+
+            await runGit(['-C', repoPath, 'fetch', 'origin'], { timeout: 60000 });
+            await runGit(['-C', repoPath, 'pull', '--ff-only'], { timeout: 60000 });
+        }
+    } catch (gitError) {
+        await fs.rm(repoPath, { recursive: true, force: true });
+        await runGit(['clone', repoUrl, repoPath], { timeout: 120000 });
+    }
+
+    return repoPath;
+}
+
+module.exports = {
+    buildGitEnv,
+    buildRepoUrl,
+    redactSecrets,
+    runGit,
+    ensureCleanOrigin,
+    cloneOrPullRepoSecure,
+};

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,3 @@
-const { exec } = require('child_process');
-const { promisify } = require('util');
-const execPromise = promisify(exec);
 const fs = require('fs/promises');
 
 require('dotenv').config();
@@ -13,6 +10,11 @@ const path = require('path');
 const { Parser } = require('json2csv');
 const ExcelJS = require('exceljs');
 const PDFDocument = require('pdfkit');
+const {
+    cloneOrPullRepoSecure,
+    redactSecrets,
+    runGit,
+} = require('./git_secure');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -477,61 +479,19 @@ async function storeRepoApiStatsForDate(repoId, repoName, dateStr, stats) {
  */
 async function cloneOrPullRepo(repoName) {
     const repoPath = path.join(REPO_STORAGE_PATH, repoName);
-    const repoUrl = `https://${GITHUB_TOKEN}@github.com/${ORG_NAME}/${repoName}.git`;
 
     try {
-        // 检查仓库目录是否存在
-        const repoExists = await fs.access(repoPath).then(() => true).catch(() => false);
-
-        if (repoExists) {
-            // 仓库存在，尝试 pull
-            try {
-                // 先检查是否是有效的 git 仓库
-                await execPromise(`git -C "${repoPath}" rev-parse --git-dir`, { timeout: 5000 });
-
-                // 尝试 pull，如果失败可能是空仓库或分支问题
-                try {
-                    await execPromise(`git -C "${repoPath}" pull --ff-only`, { timeout: 60000 });
-                } catch (pullError) {
-                    // 如果 pull 失败，检查是否是空仓库或分支问题
-                    const branchCheck = await execPromise(`git -C "${repoPath}" branch -r`, { timeout: 5000 }).catch(() => null);
-                    if (!branchCheck || !branchCheck.stdout.trim()) {
-                        console.warn(`${repoName}: 仓库为空或没有远程分支，跳过`);
-                        // 返回路径但标记为无效
-                        return repoPath;
-                    }
-                    // 尝试 fetch 然后 pull
-                    console.warn(`${repoName}: Pull failed, trying fetch...`);
-                    await execPromise(`git -C "${repoPath}" fetch origin`, { timeout: 60000 });
-                    await execPromise(`git -C "${repoPath}" pull --ff-only`, { timeout: 60000 });
-                }
-            } catch (gitError) {
-                // 如果不是有效的 git 仓库，删除并重新克隆
-                console.warn(`${repoName}: not availabe, trying re-clone...`);
-                await fs.rm(repoPath, { recursive: true, force: true });
-                await execPromise(`git clone ${repoUrl} ${repoPath}`, { timeout: 120000 });
-            }
-        } else {
-            // 仓库不存在，克隆
-            console.log(`Cloning repo: ${repoName}`);
-            try {
-                await execPromise(`git clone ${repoUrl} ${repoPath}`, { timeout: 120000 });
-            } catch (cloneError) {
-                // 克隆失败可能是仓库不存在或为空
-                console.error(`${repoName}: cloning failed: ${cloneError.message}`);
-                // 创建一个空目录，后续 git log 会返回空结果
-                await fs.mkdir(repoPath, { recursive: true });
-                return repoPath;
-            }
-        }
+        return await cloneOrPullRepoSecure({
+            repoName,
+            repoStoragePath: REPO_STORAGE_PATH,
+            orgName: ORG_NAME,
+        });
     } catch (error) {
-        console.error(`${repoName}: operate failed: ${error.message}`);
+        console.error(`${repoName}: operate failed\n${redactSecrets(error.message)}`);
         // 确保目录存在，即使 git 操作失败
         await fs.mkdir(repoPath, { recursive: true }).catch(() => { });
         return repoPath;
     }
-
-    return repoPath;
 }
 
 /**
@@ -551,10 +511,16 @@ async function getCommitStats(repoName, targetDate) {
     const endISO = formatDate(endDate);
     const startISO = formatDate(startDate);
 
-    const command = `git -C "${repoPath}" log --since="${startISO}" --until="${endISO}" --pretty=format:"COMMIT_SEPARATOR%an" --numstat`;
-
     try {
-        const { stdout } = await execPromise(command, { maxBuffer: 1024 * 1024 * 10 });
+        const { stdout } = await runGit([
+            '-C',
+            repoPath,
+            'log',
+            `--since=${startISO}`,
+            `--until=${endISO}`,
+            '--pretty=format:COMMIT_SEPARATOR%an',
+            '--numstat',
+        ], { maxBuffer: 1024 * 1024 * 10 });
         if (!stdout.trim()) {
             return { new_commits: 0, lines_added: 0, lines_deleted: 0, committers: new Set() };
         }
@@ -609,7 +575,7 @@ async function getCommitStats(repoName, targetDate) {
         };
 
     } catch (error) {
-        console.error(`Git command failed for ${repoName}:`, error.message);
+        console.error(`Git command failed for ${repoName}\n${redactSecrets(error.message)}`);
         return { new_commits: 0, lines_added: 0, lines_deleted: 0, committers: new Set() };
     }
 }


### PR DESCRIPTION
## Summary

  This PR fixes a credential exposure risk in backend Git operations.

  The backend previously embedded `GITHUB_TOKEN` directly into GitHub clone URLs. When `git clone`, `git pull`, or `git fetch` failed, the resulting error output could expose the PAT in
  terminal logs and collected runtime logs.

  ## What changed

  - Added `backend/git_secure.js` to centralize secure Git authentication, execution, and log redaction
  - Stopped embedding `GITHUB_TOKEN` in repository URLs and now always use clean `https://github.com/<org>/<repo>.git` URLs
  - Passed GitHub authentication to Git through `http.https://github.com/.extraheader` in the child process environment
  - Replaced shell-string Git execution with argument-based Git invocation
  - Redacted sensitive values from Git error output before logging
  - Normalized existing local repo `origin` URLs to clean GitHub URLs before pull/fetch
  - Updated `backend/server.js` to use the shared secure Git flow
  - Updated `backend/backfill_single_repo.js` to use the shared secure Git flow
  - Updated `backend/fix_git_stats.js` to use the shared secure Git flow

  ## Validation

  - `node --check` passed for the affected backend files
  - Confirmed the old tokenized GitHub URL pattern is no longer present in the affected backend files
  - Simulated a Git failure with an unreachable proxy and verified the error output no longer prints the PAT
  - Verified that an affected local repo now reports a clean `origin` URL in the form `https://github.com/<org>/<repo>.git`