### PR TITLE
ci(backend): add Node.js 20 test workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,39 @@
+name: Backend CI
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'backend/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Backend Tests (Node.js 20)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -4,10 +4,12 @@ on:
     branches: [main]
     paths:
       - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #46

Adds a GitHub Actions workflow for backend CI that:
- Runs on PRs and main branch pushes (with path filter for backend/**)
- Uses Node.js 20
- Runs npm ci + npm test
- Uses read-only permissions, no secrets
