### PR TITLE
fix(backend): always close export database pool

### DIFF
--- a/backend/export_data.js
+++ b/backend/export_data.js
@@ -144,28 +144,33 @@ async function exportToExcel(data) {
  */
 async function main() {
     console.log('--- [START] Data Export ---');
-    
-    // 确保输出目录存在
-    if (!fs.existsSync(OUTPUT_DIR)){
-        fs.mkdirSync(OUTPUT_DIR);
+
+    try {
+        // 确保输出目录存在
+        if (!fs.existsSync(OUTPUT_DIR)) {
+            fs.mkdirSync(OUTPUT_DIR);
+        }
+
+        const data = await fetchDataForExport(30);
+
+        if (data.length === 0) {
+            console.warn('No data found for the specified period. Nothing to export.');
+            return;
+        }
+
+        exportToCsv(data);
+        exportToJson(data);
+        await exportToExcel(data);
+
+        console.log('\n--- [FINISH] Export Complete ---');
+    } finally {
+        await pool.end();
     }
-
-    const data = await fetchDataForExport(30); // 默认导出最近30天
-
-    if (data.length === 0) {
-        console.warn('No data found for the specified period. Nothing to export.');
-        return;
-    }
-
-    exportToCsv(data);
-    exportToJson(data);
-    await exportToExcel(data);
-
-    console.log('\n--- [FINISH] Export Complete ---');
-    await pool.end();
 }
 
-main().catch(err => {
-    console.error('An error occurred during the export script:', err);
-    pool.end();
-});
+if (require.main === module) {
+    main().catch(err => {
+        console.error('An error occurred during the export script:', err);
+        process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## Summary

Fixes #43.

- Move database pool cleanup into a `finally` block.
- Ensure the pool is closed on successful export, empty data, and errors.
- Keep the existing 30-day export range unchanged.
- Preserve existing CSV, JSON, and Excel export behavior and filenames.
- Prevent `export_data.js` from automatically running when imported.
- Preserve non-success error behavior and original error diagnostics.

## Testing

- `cd backend && npm test`
- `git diff --check`

All 15 backend tests pass.