### PR TITLE
feat: 完善俱乐部首页信息与统计口径

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ psql -d oss_dashboard -f db/seed.sql
 psql -d oss_dashboard -f db/contributors_schema.sql
 ```
 
-从旧版本升级已有数据库时，先执行 Custom Property 迁移：
+不使用 Docker Compose、从旧版本升级已有数据库时，按顺序执行迁移：
 
 ```bash
 psql -d oss_dashboard -f db/migrations/001_github_custom_property_sigs.sql
@@ -268,6 +268,7 @@ npm run dev
 ```bash
 docker compose up -d --build
 docker compose ps
+docker compose logs migrate
 docker compose logs backend
 docker compose logs frontend
 docker compose logs postgres
@@ -277,6 +278,8 @@ docker compose exec backend node run_graphql_backfill.js 30 --flush-cache
 docker compose down
 docker compose down -v --rmi local
 ```
+
+Compose 会在 backend 启动前运行一次性 `migrate` 服务；迁移失败时 backend 不会启动。该服务会按文件名顺序执行 `db/migrations/*.sql`，已有迁移可安全重复执行。
 
 ### 后端
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,10 @@ psql -d oss_dashboard -f db/contributors_schema.sql
 
 ```bash
 psql -d oss_dashboard -f db/migrations/001_github_custom_property_sigs.sql
+psql -d oss_dashboard -f db/migrations/002_repository_organization_membership.sql
 ```
+
+执行 `002` 后需启动后端或运行 `npm run sync-repository-sigs`，以 GitHub 当前仓库列表更新组织成员状态。
 
 如需启用可选物化视图：
 
@@ -345,6 +348,7 @@ npm run lint
 - **仓库归属**：以 GitHub 组织仓库的 `osd_sig` Custom Property 为唯一来源，不再维护仓库映射文件
 - **属性同步**：后端启动、定时采集和回填前都会完整读取并同步 `osd_sig`
 - **排除状态**：`osd_sig=untracked` 的仓库保留原始历史快照，但不参与后续采集和 SIG/组织聚合
+- **组织成员状态**：删除或转移出 GitHub 组织的仓库保留历史数据，但不再计入当前组织仓库数
 - **稳定身份**：数据库保存 GitHub `repository_id`，仓库重命名时沿用原记录和全部历史数据
 - **历史迁移**：仓库切换 SIG 或切换到/离开 `untracked` 时，会按当前归属重新聚合已有历史快照和贡献者汇总
 - **自动更新**：后端服务默认每 6 小时自动采集一次新数据

--- a/backend/repository_sig_sync.js
+++ b/backend/repository_sig_sync.js
@@ -402,7 +402,7 @@ async function applyRepositorySigAssignments({ pool, assignments, orgName = DEFA
         }
 
         const existingResult = await client.query(
-            `SELECT r.id, r.github_id, r.name, r.sig_id, sig.slug AS sig_slug
+            `SELECT r.id, r.github_id, r.name, r.sig_id, r.is_in_organization, sig.slug AS sig_slug
              FROM repositories r
              LEFT JOIN special_interest_groups sig ON sig.id = r.sig_id
              WHERE r.org_id = $1`,
@@ -486,8 +486,8 @@ async function applyRepositorySigAssignments({ pool, assignments, orgName = DEFA
 
             if (!existing) {
                 await client.query(
-                    `INSERT INTO repositories (org_id, sig_id, github_id, name)
-                     VALUES ($1, $2, $3, $4)`,
+                    `INSERT INTO repositories (org_id, sig_id, github_id, name, is_in_organization)
+                     VALUES ($1, $2, $3, $4, TRUE)`,
                     [orgId, targetSigId, assignment.repositoryId, assignment.repositoryName]
                 );
                 if (targetSigId !== null) {
@@ -501,10 +501,11 @@ async function applyRepositorySigAssignments({ pool, assignments, orgName = DEFA
             const mappingChanged = existing.sig_slug !== assignment.sigSlug;
             const nameChanged = existing.name !== assignment.repositoryName;
             const githubIdChanged = existing.github_id === null;
-            if (mappingChanged || nameChanged || githubIdChanged) {
+            const membershipChanged = existing.is_in_organization === false;
+            if (mappingChanged || nameChanged || githubIdChanged || membershipChanged) {
                 await client.query(
                     `UPDATE repositories
-                     SET name = $1, sig_id = $2, github_id = $3
+                     SET name = $1, sig_id = $2, github_id = $3, is_in_organization = TRUE
                      WHERE id = $4`,
                     [assignment.repositoryName, targetSigId, assignment.repositoryId, existing.id]
                 );
@@ -520,24 +521,37 @@ async function applyRepositorySigAssignments({ pool, assignments, orgName = DEFA
                     affectedSigIds.add(targetSigId);
                 }
             }
-            if (mappingChanged || nameChanged) {
+            if (mappingChanged || nameChanged || membershipChanged) {
                 changes.push({
                     repository: assignment.repositoryName,
                     ...(nameChanged ? { previousRepository: existing.name } : {}),
                     from: existing.sig_slug,
                     to: assignment.sigSlug,
+                    ...(membershipChanged ? { isInOrganization: true } : {}),
                 });
             }
         }
 
         for (const repository of existingResult.rows) {
-            if (!matchedRepositoryIds.has(repository.id) && repository.sig_id !== null) {
+            if (matchedRepositoryIds.has(repository.id) || repository.is_in_organization === false) {
+                continue;
+            }
+
+            if (repository.sig_id !== null) {
                 affectedSigIds.add(repository.sig_id);
-                await client.query('UPDATE repositories SET sig_id = NULL WHERE id = $1', [repository.id]);
-                changes.push({ repository: repository.name, from: repository.sig_slug, to: null });
-                disabled += 1;
                 trackingChanged = true;
             }
+            await client.query(
+                'UPDATE repositories SET sig_id = NULL, is_in_organization = FALSE WHERE id = $1',
+                [repository.id]
+            );
+            changes.push({
+                repository: repository.name,
+                from: repository.sig_slug,
+                to: null,
+                isInOrganization: false,
+            });
+            disabled += 1;
         }
 
         const reaggregation = await reaggregateAffectedHistoricalSnapshots(

--- a/backend/server.js
+++ b/backend/server.js
@@ -1410,8 +1410,10 @@ app.get('/api/v1/organization/summary', async (req, res) => {
                 COALESCE(SUM(new_commits), 0) as new_commits,
                 COALESCE(SUM(lines_added), 0) as lines_added,
                 COALESCE(SUM(lines_deleted), 0) as lines_deleted,
-                (SELECT COUNT(*) FROM repositories WHERE org_id = $1) as organization_repositories,
-                (SELECT COUNT(*) FROM repositories WHERE org_id = $1 AND sig_id IS NOT NULL) as tracked_repositories,
+                (SELECT COUNT(*) FROM repositories
+                 WHERE org_id = $1 AND is_in_organization = TRUE) as organization_repositories,
+                (SELECT COUNT(*) FROM repositories
+                 WHERE org_id = $1 AND is_in_organization = TRUE AND sig_id IS NOT NULL) as tracked_repositories,
                 -- 为了调试和验证，可以返回统计了多少天的数据
                 COUNT(*) as days_counted 
              FROM activity_snapshots

--- a/backend/server.js
+++ b/backend/server.js
@@ -1410,6 +1410,8 @@ app.get('/api/v1/organization/summary', async (req, res) => {
                 COALESCE(SUM(new_commits), 0) as new_commits,
                 COALESCE(SUM(lines_added), 0) as lines_added,
                 COALESCE(SUM(lines_deleted), 0) as lines_deleted,
+                (SELECT COUNT(*) FROM repositories WHERE org_id = $1) as organization_repositories,
+                (SELECT COUNT(*) FROM repositories WHERE org_id = $1 AND sig_id IS NOT NULL) as tracked_repositories,
                 -- 为了调试和验证，可以返回统计了多少天的数据
                 COUNT(*) as days_counted 
              FROM activity_snapshots
@@ -1436,6 +1438,8 @@ app.get('/api/v1/organization/summary', async (req, res) => {
             new_commits: parseInt(summaryResult.rows[0].new_commits, 10),
             lines_added: parseInt(summaryResult.rows[0].lines_added, 10),
             lines_deleted: parseInt(summaryResult.rows[0].lines_deleted, 10),
+            organization_repositories: parseInt(summaryResult.rows[0].organization_repositories, 10),
+            tracked_repositories: parseInt(summaryResult.rows[0].tracked_repositories, 10),
             active_contributors: parseInt(contributorCountResult.rows[0].unique_contributors, 10),
             days_counted: parseInt(summaryResult.rows[0].days_counted, 10),
             range_days: days, // 在响应中包含请求的范围

--- a/backend/test/repository_sig_sync.test.js
+++ b/backend/test/repository_sig_sync.test.js
@@ -123,11 +123,13 @@ test('database synchronization preserves untracked rows and reaggregates changed
             if (compact.startsWith('SELECT r.id, r.github_id')) {
                 return {
                     rows: [
-                        { id: 10, github_id: null, name: 'tracked-old', sig_id: 2, sig_slug: 'linux-kernel' },
-                        { id: 11, github_id: null, name: 'removed-repo', sig_id: 3, sig_slug: 'r2' },
-                        { id: 12, github_id: null, name: 'already-untracked', sig_id: null, sig_slug: null },
+                        { id: 10, github_id: null, name: 'tracked-old', sig_id: 2, sig_slug: 'linux-kernel', is_in_organization: true },
+                        { id: 11, github_id: null, name: 'removed-repo', sig_id: 3, sig_slug: 'r2', is_in_organization: true },
+                        { id: 12, github_id: null, name: 'already-untracked', sig_id: null, sig_slug: null, is_in_organization: true },
+                        { id: 13, github_id: '304', name: 'removed-untracked', sig_id: null, sig_slug: null, is_in_organization: true },
+                        { id: 14, github_id: '305', name: 'historical-repo', sig_id: null, sig_slug: null, is_in_organization: false },
                     ],
-                    rowCount: 3,
+                    rowCount: 5,
                 };
             }
             if (compact.includes('INSERT INTO sig_snapshots')) {
@@ -160,10 +162,10 @@ test('database synchronization preserves untracked rows and reaggregates changed
     assert.equal(result.tracked, 2);
     assert.equal(result.untracked, 1);
     assert.equal(result.created, 1);
-    assert.equal(result.disabled, 1);
+    assert.equal(result.disabled, 2);
     assert.deepEqual(
         result.changes.map((change) => change.repository).sort(),
-        ['new-repo', 'removed-repo', 'tracked-old']
+        ['new-repo', 'removed-repo', 'removed-untracked', 'tracked-old']
     );
     assert.equal(result.reaggregation.sigSnapshots, 12);
     assert.equal(result.reaggregation.organizationSnapshots, 6);
@@ -177,6 +179,14 @@ test('database synchronization preserves untracked rows and reaggregates changed
         && query.sql.includes('NOT EXISTS')
     ));
     assert.ok(queries.some((query) => query.sql.includes('HAVING BOOL_OR')));
+    assert.ok(queries.some((query) =>
+        query.sql === 'UPDATE repositories SET sig_id = NULL, is_in_organization = FALSE WHERE id = $1'
+        && query.params[0] === 13
+    ));
+    assert.ok(!queries.some((query) =>
+        query.sql.includes('is_in_organization = FALSE')
+        && query.params[0] === 14
+    ));
     assert.ok(queries.some((query) => query.sql === 'COMMIT'));
     assert.ok(!queries.some((query) => query.sql === 'ROLLBACK'));
     assert.equal(queries.at(-1).sql, 'RELEASE');
@@ -235,6 +245,64 @@ test('database synchronization matches a renamed repository by GitHub ID', async
     assert.ok(!queries.some((query) => query.sql.includes('INSERT INTO repositories (org_id')));
 });
 
+test('database synchronization reactivates a repository that returns to the organization', async () => {
+    const queries = [];
+    const sigIds = new Map(Object.keys(SIG_DEFINITIONS).map((slug, index) => [slug, 100 + index]));
+    const client = {
+        async query(sql, params = []) {
+            queries.push({ sql, params });
+            const compact = sql.replace(/\s+/g, ' ').trim();
+            if (compact === 'BEGIN' || compact === 'COMMIT' || compact === 'ROLLBACK') {
+                return { rows: [], rowCount: 0 };
+            }
+            if (compact.startsWith('INSERT INTO organizations')) {
+                return { rows: [{ id: 1 }], rowCount: 1 };
+            }
+            if (compact.startsWith('INSERT INTO special_interest_groups')) {
+                return { rows: [{ id: sigIds.get(params[1]) }], rowCount: 1 };
+            }
+            if (compact.startsWith('SELECT r.id, r.github_id')) {
+                return {
+                    rows: [{
+                        id: 10,
+                        github_id: '98765',
+                        name: 'returning-repo',
+                        sig_id: null,
+                        sig_slug: null,
+                        is_in_organization: false,
+                    }],
+                    rowCount: 1,
+                };
+            }
+            return { rows: [], rowCount: 1 };
+        },
+        release() {},
+    };
+
+    const result = await applyRepositorySigAssignments({
+        pool: { async connect() { return client; } },
+        assignments: [{
+            repositoryId: '98765',
+            repositoryName: 'returning-repo',
+            propertyValue: 'untracked',
+            sigSlug: null,
+        }],
+    });
+
+    assert.equal(result.created, 0);
+    assert.equal(result.disabled, 0);
+    assert.deepEqual(result.changes, [{
+        repository: 'returning-repo',
+        from: null,
+        to: null,
+        isInOrganization: true,
+    }]);
+    assert.ok(queries.some((query) =>
+        query.sql.includes('is_in_organization = TRUE')
+        && query.params[3] === 10
+    ));
+});
+
 test('database synchronization preserves an old identity when its repository name is reused', async () => {
     const queries = [];
     const sigIds = new Map(Object.keys(SIG_DEFINITIONS).map((slug, index) => [slug, 100 + index]));
@@ -285,7 +353,7 @@ test('database synchronization preserves an old identity when its repository nam
         && query.params[3] === 'reused-name'
     ));
     assert.ok(queries.some((query) =>
-        query.sql === 'UPDATE repositories SET sig_id = NULL WHERE id = $1'
+        query.sql === 'UPDATE repositories SET sig_id = NULL, is_in_organization = FALSE WHERE id = $1'
         && query.params[0] === 10
     ));
     assert.ok(queries.some((query) => query.sql === 'COMMIT'));

--- a/db/migrations/002_repository_organization_membership.sql
+++ b/db/migrations/002_repository_organization_membership.sql
@@ -1,0 +1,25 @@
+\encoding UTF8
+\set ON_ERROR_STOP on
+SET client_encoding = 'UTF8';
+
+BEGIN;
+
+ALTER TABLE repositories
+ADD COLUMN IF NOT EXISTS is_in_organization BOOLEAN;
+
+-- Existing rows remain current until the required metadata synchronization
+-- below compares them with the complete GitHub Custom Property assignment set.
+UPDATE repositories
+SET is_in_organization = TRUE
+WHERE is_in_organization IS NULL;
+
+ALTER TABLE repositories
+ALTER COLUMN is_in_organization SET DEFAULT TRUE;
+
+ALTER TABLE repositories
+ALTER COLUMN is_in_organization SET NOT NULL;
+
+COMMIT;
+
+-- After applying this migration, run the repository metadata synchronization:
+-- npm run sync-repository-sigs

--- a/db/run-migrations.sh
+++ b/db/run-migrations.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+for migration in /db-source/migrations/*.sql; do
+    if [ ! -f "$migration" ]; then
+        continue
+    fi
+
+    echo "Applying database migration: $(basename "$migration")"
+    psql --set ON_ERROR_STOP=1 --file "$migration"
+done

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -28,6 +28,7 @@ CREATE TABLE repositories (
     org_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
     sig_id INTEGER REFERENCES special_interest_groups(id) ON DELETE SET NULL, -- NULL means osd_sig=untracked
     github_id BIGINT UNIQUE, -- Stable GitHub repository identity, preserved across renames
+    is_in_organization BOOLEAN NOT NULL DEFAULT TRUE, -- False retains history for repositories no longer in the GitHub organization
     name VARCHAR(255) NOT NULL, -- 仓库名称，如 hust-mirrors
     description TEXT,
     created_at TIMESTAMPTZ DEFAULT NOW(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,21 @@ services:
       retries: 10
       start_period: 5s
 
+  migrate:
+    image: postgres:16
+    restart: "no"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGHOST: postgres
+      PGUSER: ${POSTGRES_USER:-postgres}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      PGDATABASE: ${POSTGRES_DB:-oss_dashboard}
+    volumes:
+      - ./db:/db-source:ro
+    command: ["/bin/sh", "/db-source/run-migrations.sh"]
+
   backend:
     build:
       context: .
@@ -44,6 +59,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     environment:
       NODE_ENV: production
       TZ: ${TZ:-Asia/Shanghai}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/hust-open-atom-club-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="华科开放原子开源俱乐部开源贡献数据看板" />
+    <meta name="theme-color" content="#111827" />
+    <meta name="description" content="聚合华科开放原子开源俱乐部各 SIG 的仓库、Commit、PR、Issue 与贡献者数据。" />
+    <meta name="keywords" content="华中科技大学,开放原子开源俱乐部,开源贡献,SIG,GitHub" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="华科开放原子开源俱乐部 · 开源贡献看板" />
+    <meta property="og:description" content="记录俱乐部的开源协作与每一次贡献。" />
+    <meta property="og:image" content="/hust-open-atom-club-logo.svg" />
     <title>华科开放原子开源俱乐部 · 开源贡献看板</title>
   </head>
   <body>

--- a/frontend/src/components/ContributorDetailModal.jsx
+++ b/frontend/src/components/ContributorDetailModal.jsx
@@ -99,15 +99,15 @@ const ContributorDetailModal = ({ username, range, onClose }) => {
                             <div className="grid grid-cols-3 gap-4">
                                 <div className="bg-gradient-to-br from-purple-500/20 to-purple-600/10 p-4 rounded-xl border border-purple-500/30">
                                     <div className="text-3xl font-bold text-purple-400">{summary.prs}</div>
-                                    <div className="text-sm text-gray-400">Pull Requests</div>
+                                    <div className="text-sm text-gray-400">PR</div>
                                 </div>
                                 <div className="bg-gradient-to-br from-green-500/20 to-green-600/10 p-4 rounded-xl border border-green-500/30">
                                     <div className="text-3xl font-bold text-green-400">{summary.issues}</div>
-                                    <div className="text-sm text-gray-400">Issues</div>
+                                    <div className="text-sm text-gray-400">Issue</div>
                                 </div>
                                 <div className="bg-gradient-to-br from-blue-500/20 to-blue-600/10 p-4 rounded-xl border border-blue-500/30">
                                     <div className="text-3xl font-bold text-blue-400">{summary.commits}</div>
-                                    <div className="text-sm text-gray-400">Commits</div>
+                                    <div className="text-sm text-gray-400">Commit</div>
                                 </div>
                             </div>
 

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -42,9 +42,9 @@ const Dashboard = () => {
     // SIG chart metric
     const [sigMetric, setSigMetric] = useState('prs');
     const sigMetrics = [
-        { key: 'prs', label: 'PRs', name: 'Pull Requests', color: '#8b5cf6' },
-        { key: 'issues', label: 'Issues', name: '议题', color: '#f59e0b' },
-        { key: 'commits', label: 'Commits', name: '提交', color: '#10b981' }
+        { key: 'prs', label: 'PR', name: 'PR', color: '#8b5cf6' },
+        { key: 'issues', label: 'Issue', name: 'Issue', color: '#f59e0b' },
+        { key: 'commits', label: 'Commit', name: 'Commit', color: '#10b981' }
     ];
 
     useEffect(() => {
@@ -173,7 +173,7 @@ const Dashboard = () => {
     }
 
     return (
-        <div className="min-h-screen bg-gray-900 text-white p-8 font-sans">
+        <div className="min-h-screen bg-gray-900 text-white p-4 font-sans md:p-8">
             {/* Toast Container */}
             <ToastContainer toasts={toasts} removeToast={removeToast} />
 
@@ -211,7 +211,7 @@ const Dashboard = () => {
                         <p className="text-lg text-gray-400 mt-1">开源贡献数据看板</p>
                     </div>
                 </div>
-                <div className="flex flex-wrap items-center gap-4">
+                <div className="flex w-full flex-wrap items-center gap-4 xl:w-auto xl:justify-end">
                     <ViewSwitcher
                         view={granularity}
                         onViewChange={setGranularity}
@@ -239,11 +239,61 @@ const Dashboard = () => {
                 </div>
             </div>
 
+            {/* Club introduction */}
+            <section className="relative overflow-hidden rounded-2xl border border-blue-500/20 bg-gradient-to-br from-blue-950/80 via-gray-800 to-purple-950/60 p-6 md:p-8 mb-8 shadow-2xl shadow-blue-950/20">
+                <div className="absolute -right-24 -top-24 h-64 w-64 rounded-full bg-blue-500/10 blur-3xl" aria-hidden="true"></div>
+                <div className="absolute -bottom-28 right-1/3 h-56 w-56 rounded-full bg-purple-500/10 blur-3xl" aria-hidden="true"></div>
+                <div className="relative grid gap-8 xl:grid-cols-[1.35fr_1fr] xl:items-center">
+                    <div>
+                        <p className="mb-3 text-xs font-semibold uppercase tracking-[0.28em] text-blue-300">HUST Open Atom Club</p>
+                        <h2 className="max-w-3xl text-2xl font-bold leading-tight text-white md:text-4xl">让每一次开源贡献，都被看见</h2>
+                        <p className="mt-4 max-w-2xl leading-7 text-gray-300">
+                            我们是由华中科技大学师生与开源爱好者共同建设的开源社区。
+                            看板聚合俱乐部各 SIG 的公开协作数据，记录我们一起写下的 Commit、PR 和 Issue。
+                        </p>
+                        <div className="mt-5 flex flex-wrap gap-2" aria-label="俱乐部价值观">
+                            {['开放', '共享', '协同', '贡献'].map(value => (
+                                <span key={value} className="rounded-full border border-blue-400/25 bg-blue-400/10 px-3 py-1 text-sm text-blue-100">{value}</span>
+                            ))}
+                        </div>
+                        <div className="mt-6 flex flex-wrap gap-3">
+                            <a
+                                href="https://github.com/hust-open-atom-club"
+                                target="_blank"
+                                rel="noreferrer"
+                                className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-500"
+                            >
+                                访问 GitHub 组织 <span className="ml-2" aria-hidden="true">↗</span>
+                            </a>
+                            <a
+                                href="#contribution-overview"
+                                className="inline-flex items-center rounded-lg border border-gray-600 bg-gray-800/70 px-4 py-2.5 text-sm font-semibold text-gray-100 transition-colors hover:border-gray-500 hover:bg-gray-700"
+                            >
+                                浏览贡献数据 <span className="ml-2" aria-hidden="true">↓</span>
+                            </a>
+                        </div>
+                    </div>
+
+                    <div className="rounded-xl border border-white/10 bg-gray-950/35 p-5 backdrop-blur-sm">
+                        <p className="text-sm font-semibold text-gray-200">看板范围</p>
+                        <div className="mt-4 grid grid-cols-3 gap-3">
+                            <ScopeStat label="纳入统计" value={summary?.tracked_repositories} unit="个仓库" />
+                            <ScopeStat label="组织仓库" value={summary?.organization_repositories} unit="个仓库" />
+                            <ScopeStat label="技术小组" value={allSigs.length} unit="个 SIG" />
+                        </div>
+                        <p className="mt-4 border-t border-white/10 pt-4 text-xs leading-5 text-gray-400">
+                            统计范围以 GitHub 仓库的 <code className="text-blue-300">osd_sig</code> 属性为准。
+                            标记为 <code className="text-gray-300">untracked</code> 的仓库不进入汇总；fork 仓库可按所属 SIG 纳入。
+                        </p>
+                    </div>
+                </div>
+            </section>
+
             {/* Summary Cards */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-                <SummaryCard title="新 Pull Requests" value={summary?.new_prs} icon="🔀" color="blue" />
-                <SummaryCard title="已合并 PRs" value={summary?.closed_merged_prs} icon="✅" color="green" />
-                <SummaryCard title="新 Commits" value={summary?.new_commits} icon="💻" color="orange" />
+            <div id="contribution-overview" className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8 scroll-mt-6">
+                <SummaryCard title="新建 PR" value={summary?.new_prs} icon="🔀" color="blue" />
+                <SummaryCard title="已合并 PR" value={summary?.closed_merged_prs} icon="✅" color="green" />
+                <SummaryCard title="新增 Commit" value={summary?.new_commits} icon="💻" color="orange" />
                 <SummaryCard title="活跃贡献者" value={summary?.active_contributors || "N/A"} subtext="(唯一)" icon="👥" color="purple" />
             </div>
 
@@ -257,11 +307,11 @@ const Dashboard = () => {
                 {/* Monthly Trends: PRs & Issues */}
                 <div className="bg-gray-800 rounded-xl p-6 border border-gray-700 shadow-xl h-96">
                     <TrendChart
-                        title={`Contribution Trends (PRs & Issues) - ${granularity === 'day' ? '日' : granularity === 'week' ? '周' : '月'}视图`}
+                        title={`贡献趋势（PR 与 Issue）· ${granularity === 'day' ? '日' : granularity === 'week' ? '周' : '月'}视图`}
                         xAxisData={timeseries.map(t => t.date)}
                         seriesData={[
-                            { name: 'New PRs', data: timeseries.map(t => t.new_prs) },
-                            { name: 'New Issues', data: timeseries.map(t => t.new_issues) }
+                            { name: '新建 PR', data: timeseries.map(t => t.new_prs) },
+                            { name: '新建 Issue', data: timeseries.map(t => t.new_issues) }
                         ]}
                         colors={['#3b82f6', '#f59e0b']}
                         onDayClick={granularity === 'day' ? handlePRIssueChartClick : undefined}
@@ -271,10 +321,10 @@ const Dashboard = () => {
                 {/* Monthly Trends: Commits */}
                 <div className="bg-gray-800 rounded-xl p-6 border border-gray-700 shadow-xl h-96">
                     <TrendChart
-                        title={`Code Activity (Commits) - ${granularity === 'day' ? '日' : granularity === 'week' ? '周' : '月'}视图`}
+                        title={`Commit 趋势 · ${granularity === 'day' ? '日' : granularity === 'week' ? '周' : '月'}视图`}
                         xAxisData={timeseries.map(t => t.date)}
                         seriesData={[
-                            { name: 'Commits', data: timeseries.map(t => t.new_commits) }
+                            { name: 'Commit', data: timeseries.map(t => t.new_commits) }
                         ]}
                         colors={['#10b981']}
                         onDayClick={granularity === 'day' ? handleCommitChartClick : undefined}
@@ -315,7 +365,7 @@ const Dashboard = () => {
                     </div>
                     <div className="flex-1">
                         <SIGComparisonChart
-                            title={`SIG Leaderboard (${sigMetrics.find(m => m.key === sigMetric)?.name})`}
+                            title={`SIG 排行（${sigMetrics.find(m => m.key === sigMetric)?.name}）`}
                             data={sigData}
                             metricKey={sigMetric}
                             metricName={sigMetrics.find(m => m.key === sigMetric)?.name}
@@ -328,10 +378,10 @@ const Dashboard = () => {
                 {/* Active Contributors Trend */}
                 <div className="bg-gray-800 rounded-xl p-6 border border-gray-700 shadow-xl h-96">
                     <TrendChart
-                        title="Active Contributors Trend"
+                        title="活跃贡献者趋势"
                         xAxisData={timeseries.map(t => t.date)}
                         seriesData={[
-                            { name: 'Active Contributors', data: timeseries.map(t => t.active_contributors) }
+                            { name: '活跃贡献者', data: timeseries.map(t => t.active_contributors) }
                         ]}
                         colors={['#ec4899']}
                         onDayClick={granularity === 'day' ? handleContributorChartClick : undefined}
@@ -351,9 +401,33 @@ const Dashboard = () => {
                 {/* Contributor Leaderboard */}
                 <ContributorLeaderboard range={range} />
             </div>
+
+            <footer className="mt-12 border-t border-gray-800 py-8 text-sm text-gray-400">
+                <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <p className="font-medium text-gray-200">华科开放原子开源俱乐部</p>
+                        <p className="mt-1">开放 · 共享 · 协同 · 贡献</p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+                        <span>数据来源：GitHub GraphQL API</span>
+                        <a className="text-blue-300 hover:text-blue-200" href="https://github.com/hust-open-atom-club" target="_blank" rel="noreferrer">
+                            GitHub 组织 ↗
+                        </a>
+                        <span>© {new Date().getFullYear()} HUST Open Atom Club</span>
+                    </div>
+                </div>
+            </footer>
         </div>
     );
 };
+
+const ScopeStat = ({ label, value, unit }) => (
+    <div className="rounded-lg border border-white/10 bg-white/5 p-3">
+        <div className="text-xl font-bold text-white md:text-2xl">{value?.toLocaleString() ?? '—'}</div>
+        <div className="mt-1 text-xs text-gray-400">{label}</div>
+        <div className="text-[11px] text-gray-500">{unit}</div>
+    </div>
+);
 
 const SummaryCard = ({ title, value, icon, color, subtext }) => {
     const colorClasses = {

--- a/frontend/src/components/DayDetailModal.jsx
+++ b/frontend/src/components/DayDetailModal.jsx
@@ -37,9 +37,9 @@ const DayDetailModal = ({ date, chartType = 'prs', onClose }) => {
     }, [onClose]);
 
     const tabs = [
-        { id: 'prs', label: 'Pull Requests', icon: '🔀', color: 'text-purple-400' },
-        { id: 'issues', label: 'Issues', icon: '📋', color: 'text-green-400' },
-        { id: 'commits', label: 'Commits', icon: '💻', color: 'text-blue-400' },
+        { id: 'prs', label: 'PR', icon: '🔀', color: 'text-purple-400' },
+        { id: 'issues', label: 'Issue', icon: '📋', color: 'text-green-400' },
+        { id: 'commits', label: 'Commit', icon: '💻', color: 'text-blue-400' },
         { id: 'contributors', label: '贡献者', icon: '👥', color: 'text-orange-400' }
     ];
 
@@ -73,15 +73,15 @@ const DayDetailModal = ({ date, chartType = 'prs', onClose }) => {
                     <div className="grid grid-cols-4 gap-4 p-6 bg-gray-800/50">
                         <div className="text-center">
                             <div className="text-2xl font-bold text-purple-400">{data.summary.new_prs}</div>
-                            <div className="text-xs text-gray-400">New PRs</div>
+                            <div className="text-xs text-gray-400">新建 PR</div>
                         </div>
                         <div className="text-center">
                             <div className="text-2xl font-bold text-green-400">{data.summary.new_issues}</div>
-                            <div className="text-xs text-gray-400">New Issues</div>
+                            <div className="text-xs text-gray-400">新建 Issue</div>
                         </div>
                         <div className="text-center">
                             <div className="text-2xl font-bold text-blue-400">{data.summary.new_commits}</div>
-                            <div className="text-xs text-gray-400">Commits</div>
+                            <div className="text-xs text-gray-400">Commit</div>
                         </div>
                         <div className="text-center">
                             <div className="text-2xl font-bold text-orange-400">{data.summary.active_contributors}</div>

--- a/frontend/src/components/GrowthReport.jsx
+++ b/frontend/src/components/GrowthReport.jsx
@@ -65,13 +65,13 @@ const GrowthReport = ({ growthData, loading }) => {
                     bgClass={getGrowthBgColor(growth.prs)}
                 />
                 <GrowthMetric 
-                    label="Issue增长" 
+                    label="Issue 增长"
                     value={growth.issues}
                     colorClass={getGrowthColor(growth.issues)}
                     bgClass={getGrowthBgColor(growth.issues)}
                 />
                 <GrowthMetric 
-                    label="Commit增长" 
+                    label="Commit 增长"
                     value={growth.commits}
                     colorClass={getGrowthColor(growth.commits)}
                     bgClass={getGrowthBgColor(growth.commits)}
@@ -107,9 +107,9 @@ const PeriodCard = ({ title, period, highlight }) => {
                 {start} 至 {end}
             </p>
             <div className="space-y-1.5">
-                <MetricRow label="PRs" value={metrics.new_prs} />
-                <MetricRow label="Issues" value={metrics.new_issues} />
-                <MetricRow label="Commits" value={metrics.new_commits} />
+                <MetricRow label="PR" value={metrics.new_prs} />
+                <MetricRow label="Issue" value={metrics.new_issues} />
+                <MetricRow label="Commit" value={metrics.new_commits} />
                 <MetricRow label="新增代码" value={metrics.lines_added} />
                 <MetricRow label="删除代码" value={metrics.lines_deleted} />
             </div>
@@ -137,4 +137,3 @@ const GrowthMetric = ({ label, value, colorClass, bgClass }) => (
 );
 
 export default GrowthReport;
-

--- a/frontend/src/components/MultiSIGComparisonChart.jsx
+++ b/frontend/src/components/MultiSIGComparisonChart.jsx
@@ -13,9 +13,9 @@ const MultiSIGComparisonChart = ({ sigs, selectedSigIds, onSigSelectionChange, m
     }, [sigs, selectedSigIds]);
 
     const metricLabels = {
-        new_prs: 'PRs',
-        new_issues: 'Issues',
-        new_commits: 'Commits',
+        new_prs: 'PR',
+        new_issues: 'Issue',
+        new_commits: 'Commit',
         lines_added: '新增代码行'
     };
 
@@ -137,4 +137,3 @@ const MultiSIGComparisonChart = ({ sigs, selectedSigIds, onSigSelectionChange, m
 };
 
 export default MultiSIGComparisonChart;
-

--- a/frontend/src/components/ViewSwitcher.jsx
+++ b/frontend/src/components/ViewSwitcher.jsx
@@ -17,11 +17,11 @@ const ViewSwitcher = ({ view, onViewChange, range, onRangeChange }) => {
     ];
 
     return (
-        <div className="flex gap-4 items-center">
+        <div className="flex w-full min-w-0 flex-col gap-3 lg:w-auto lg:flex-row lg:items-center">
             {/* Granularity Switcher */}
-            <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-400">粒度:</span>
-                <div className="bg-gray-800 rounded-lg p-1 border border-gray-700 flex">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <span className="text-sm text-gray-400">粒度：</span>
+                <div className="flex flex-wrap rounded-lg border border-gray-700 bg-gray-800 p-1">
                     {viewOptions.map(option => (
                         <button
                             key={option.value}
@@ -38,9 +38,9 @@ const ViewSwitcher = ({ view, onViewChange, range, onRangeChange }) => {
             </div>
 
             {/* Time Range Switcher */}
-            <div className="flex items-center gap-2">
-                <span className="text-sm text-gray-400">时间范围:</span>
-                <div className="bg-gray-800 rounded-lg p-1 border border-gray-700 flex">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <span className="text-sm text-gray-400">时间范围：</span>
+                <div className="flex flex-wrap rounded-lg border border-gray-700 bg-gray-800 p-1">
                     {rangeOptions.map(option => (
                         <button
                             key={option.value}
@@ -60,4 +60,3 @@ const ViewSwitcher = ({ view, onViewChange, range, onRangeChange }) => {
 };
 
 export default ViewSwitcher;
-


### PR DESCRIPTION
## 变更内容

- 扩展首页品牌区域，补充俱乐部简介、“开放、共享、协同、贡献”价值主张，以及 GitHub 和贡献入口
- 在组织汇总 API 中返回当前组织仓库数与被跟踪仓库数，并在首页展示仓库与 SIG 范围
- 使用独立的组织成员状态保留已删除或转移仓库的历史数据，同时将其排除在当前组织仓库数之外
- 通过一次性 Compose `migrate` 服务，在 backend 启动前自动升级持久化 PostgreSQL 数据库
- 解释 `osd_sig`、`untracked` 和 fork 仓库的统计口径
- 补充页脚、中文网页标题、favicon、SEO 和 Open Graph 元数据
- 统一页面周边中文文案，同时保留 PR、Issue、Commit 等术语
- 改善移动端筛选控件布局，避免窄屏横向溢出

## 验证

- `git diff --check`
- tcloud 后端：`npm test`（33/33 通过）
- tcloud PostgreSQL 16：旧库迁移及迁移重复执行通过，当前组织/跟踪仓库计数符合预期
- tcloud Docker Compose：shell 与 Compose 配置检查通过；模拟旧持久化卷后，`migrate` 首次及重复启动均成功退出并补齐字段
- tcloud 前端：`npm run build`
- 桌面端与 390px 移动端预览检查通过；无横向溢出，浏览器控制台无错误

## 已知状态

- 仓库级 `npm run lint` 仍有既存的 6 个 error 和 7 个 warning；本次改动未新增 lint 诊断
- 本 PR 不包含生产部署变更

