### PR TITLE
feat: add repository activity insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ npm run lint
 | 接口 | 描述 |
 |------|------|
 | `GET /api/v1/organization/sigs` | 获取所有 SIG 列表 |
+| `GET /api/v1/organization/repositories` | 获取指定时间范围内的仓库级活动汇总 |
 | `GET /api/v1/organization/timeseries` | 获取组织时间序列数据 |
 | `GET /api/v1/sig/:sigId/timeseries` | 获取 SIG 时间序列数据 |
 | `GET /api/v1/organization/latest-activity` | 获取最新活动列表 |

--- a/backend/repository_insights.js
+++ b/backend/repository_insights.js
@@ -129,8 +129,27 @@ function mapRepositoryInsightRows(rows, organizationName) {
     return rows.map((row) => mapRepositoryInsightRow(row, organizationName));
 }
 
+async function invalidateRepositoryInsightCache(redisClient, organizationName) {
+    const pattern = `org:${organizationName}:repositories:range:*`;
+    const cacheKeys = [];
+
+    for await (const key of redisClient.scanIterator({
+        MATCH: pattern,
+        COUNT: 100,
+    })) {
+        cacheKeys.push(key);
+    }
+
+    if (cacheKeys.length > 0) {
+        await redisClient.del(cacheKeys);
+    }
+
+    return cacheKeys.length;
+}
+
 module.exports = {
     REPOSITORY_INSIGHTS_SQL,
+    invalidateRepositoryInsightCache,
     mapRepositoryInsightRow,
     mapRepositoryInsightRows,
 };

--- a/backend/repository_insights.js
+++ b/backend/repository_insights.js
@@ -1,0 +1,136 @@
+const { buildHumanContributorSqlCondition } = require('./contributor_filters');
+
+const HUMAN_CONTRIBUTOR_SQL = buildHumanContributorSqlCondition('c.github_username');
+
+const REPOSITORY_INSIGHTS_SQL = `
+    WITH eligible_repositories AS (
+        SELECT
+            r.id,
+            r.name,
+            sig.id AS sig_id,
+            sig.name AS sig_name
+        FROM repositories r
+        JOIN special_interest_groups sig ON sig.id = r.sig_id
+        WHERE r.org_id = $1
+          AND r.is_in_organization = TRUE
+          AND r.sig_id IS NOT NULL
+    ),
+    snapshot_totals AS (
+        SELECT
+            rs.repo_id,
+            COALESCE(SUM(rs.new_prs), 0) AS new_prs,
+            COALESCE(SUM(rs.closed_merged_prs), 0) AS closed_merged_prs,
+            COALESCE(SUM(rs.new_issues), 0) AS new_issues,
+            COALESCE(SUM(rs.closed_issues), 0) AS closed_issues,
+            COALESCE(SUM(rs.new_commits), 0) AS new_commits,
+            COALESCE(SUM(rs.lines_added), 0) AS lines_added,
+            COALESCE(SUM(rs.lines_deleted), 0) AS lines_deleted,
+            MAX(rs.snapshot_date) FILTER (
+                WHERE rs.new_prs <> 0
+                   OR rs.closed_merged_prs <> 0
+                   OR rs.new_issues <> 0
+                   OR rs.closed_issues <> 0
+                   OR rs.new_commits <> 0
+            ) AS last_active_date
+        FROM repo_snapshots rs
+        JOIN eligible_repositories er ON er.id = rs.repo_id
+        WHERE rs.snapshot_date >= $2
+        GROUP BY rs.repo_id
+    ),
+    contributor_totals AS (
+        SELECT
+            cra.repo_id,
+            COUNT(DISTINCT cra.contributor_id) AS active_contributors
+        FROM contributor_repo_activities cra
+        JOIN eligible_repositories er ON er.id = cra.repo_id
+        JOIN contributors c ON c.id = cra.contributor_id
+        WHERE cra.snapshot_date >= $2
+          AND ${HUMAN_CONTRIBUTOR_SQL}
+          AND (
+              cra.prs_opened <> 0
+              OR cra.prs_closed <> 0
+              OR cra.issues_opened <> 0
+              OR cra.issues_closed <> 0
+              OR cra.commits_count <> 0
+              OR cra.lines_added <> 0
+              OR cra.lines_deleted <> 0
+          )
+        GROUP BY cra.repo_id
+    )
+    SELECT
+        er.id,
+        er.name,
+        er.sig_id,
+        er.sig_name,
+        COALESCE(st.new_prs, 0) AS new_prs,
+        COALESCE(st.closed_merged_prs, 0) AS closed_merged_prs,
+        COALESCE(st.new_issues, 0) AS new_issues,
+        COALESCE(st.closed_issues, 0) AS closed_issues,
+        COALESCE(st.new_commits, 0) AS new_commits,
+        COALESCE(st.lines_added, 0) AS lines_added,
+        COALESCE(st.lines_deleted, 0) AS lines_deleted,
+        COALESCE(ct.active_contributors, 0) AS active_contributors,
+        st.last_active_date
+    FROM eligible_repositories er
+    LEFT JOIN snapshot_totals st ON st.repo_id = er.id
+    LEFT JOIN contributor_totals ct ON ct.repo_id = er.id
+    ORDER BY er.name ASC`;
+
+function toInteger(value) {
+    return Number.parseInt(value, 10) || 0;
+}
+
+function formatSnapshotDate(value) {
+    if (!value) {
+        return null;
+    }
+
+    if (typeof value === 'string') {
+        return value.slice(0, 10);
+    }
+
+    const year = value.getFullYear();
+    const month = String(value.getMonth() + 1).padStart(2, '0');
+    const day = String(value.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+function mapRepositoryInsightRow(row, organizationName) {
+    const metrics = {
+        new_prs: toInteger(row.new_prs),
+        closed_merged_prs: toInteger(row.closed_merged_prs),
+        new_issues: toInteger(row.new_issues),
+        closed_issues: toInteger(row.closed_issues),
+        new_commits: toInteger(row.new_commits),
+        active_contributors: toInteger(row.active_contributors),
+        lines_added: toInteger(row.lines_added),
+        lines_deleted: toInteger(row.lines_deleted),
+    };
+
+    return {
+        id: toInteger(row.id),
+        name: row.name,
+        url: `https://github.com/${organizationName}/${encodeURIComponent(row.name)}`,
+        sig: {
+            id: toInteger(row.sig_id),
+            name: row.sig_name,
+        },
+        ...metrics,
+        is_active: metrics.new_prs > 0
+            || metrics.closed_merged_prs > 0
+            || metrics.new_issues > 0
+            || metrics.closed_issues > 0
+            || metrics.new_commits > 0,
+        last_active_date: formatSnapshotDate(row.last_active_date),
+    };
+}
+
+function mapRepositoryInsightRows(rows, organizationName) {
+    return rows.map((row) => mapRepositoryInsightRow(row, organizationName));
+}
+
+module.exports = {
+    REPOSITORY_INSIGHTS_SQL,
+    mapRepositoryInsightRow,
+    mapRepositoryInsightRows,
+};

--- a/backend/server.js
+++ b/backend/server.js
@@ -31,6 +31,10 @@ const {
     storeContributorActivities: persistContributorActivities,
 } = require('./contributor_api_stats');
 const { collectAndPersistRepoApiStats } = require('./repo_api_ingestion');
+const {
+    REPOSITORY_INSIGHTS_SQL,
+    mapRepositoryInsightRows,
+} = require('./repository_insights');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -1329,6 +1333,39 @@ app.get('/api/v1/organization/sigs', async (req, res) => {
         res.json(sigsResult.rows);
     } catch (error) {
         console.error('Error fetching SIGs:', error.message);
+        res.status(500).json({ error: 'Internal Server Error' });
+    }
+});
+
+// GET /api/v1/organization/repositories - Repository-level activity in a selected range
+app.get('/api/v1/organization/repositories', async (req, res) => {
+    const range = req.query.range || '30d';
+    const cacheKey = `org:${ORG_NAME}:repositories:range:${range}`;
+    const cacheTTL = 60 * 10;
+
+    try {
+        const org = await getMonitoredOrg();
+        if (!org) {
+            return res.status(404).json({ error: 'Monitored organization not found.' });
+        }
+
+        const cachedData = await redisClient.get(cacheKey);
+        if (cachedData) {
+            return res.json(JSON.parse(cachedData));
+        }
+
+        const { startDateStr } = parseRange(range);
+        const result = await pool.query(REPOSITORY_INSIGHTS_SQL, [org.id, startDateStr]);
+        const repositories = mapRepositoryInsightRows(result.rows, ORG_NAME);
+        const responseData = {
+            range,
+            repositories,
+        };
+
+        await redisClient.setEx(cacheKey, cacheTTL, JSON.stringify(responseData));
+        res.json(responseData);
+    } catch (error) {
+        console.error('Error fetching repository insights:', error.message);
         res.status(500).json({ error: 'Internal Server Error' });
     }
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -33,6 +33,7 @@ const {
 const { collectAndPersistRepoApiStats } = require('./repo_api_ingestion');
 const {
     REPOSITORY_INSIGHTS_SQL,
+    invalidateRepositoryInsightCache,
     mapRepositoryInsightRows,
 } = require('./repository_insights');
 
@@ -724,6 +725,9 @@ async function refreshCache() {
             console.log('Organization not found. Skipping cache refresh.');
             return;
         }
+
+        const invalidatedRepositoryCacheKeys = await invalidateRepositoryInsightCache(redisClient, ORG_NAME);
+        console.log(`Invalidated ${invalidatedRepositoryCacheKeys} repository insight cache keys`);
 
         // 刷新组织时间序列数据（30天）
         const range = '30d';

--- a/backend/test/repository_insights.test.js
+++ b/backend/test/repository_insights.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 
 const {
     REPOSITORY_INSIGHTS_SQL,
+    invalidateRepositoryInsightCache,
     mapRepositoryInsightRow,
 } = require('../repository_insights');
 
@@ -72,4 +73,33 @@ test('does not classify code-line totals without a PR, issue, or commit as repos
     }, 'example-org');
 
     assert.equal(result.is_active, false);
+});
+
+test('invalidates repository insight caches for every range after ingestion', async () => {
+    const scannedOptions = [];
+    const deletedKeys = [];
+    const redisClient = {
+        async *scanIterator(options) {
+            scannedOptions.push(options);
+            yield 'org:example-org:repositories:range:7d';
+            yield 'org:example-org:repositories:range:30d';
+            yield 'org:example-org:repositories:range:all';
+        },
+        async del(keys) {
+            deletedKeys.push(...keys);
+        },
+    };
+
+    const invalidatedCount = await invalidateRepositoryInsightCache(redisClient, 'example-org');
+
+    assert.deepEqual(scannedOptions, [{
+        MATCH: 'org:example-org:repositories:range:*',
+        COUNT: 100,
+    }]);
+    assert.deepEqual(deletedKeys, [
+        'org:example-org:repositories:range:7d',
+        'org:example-org:repositories:range:30d',
+        'org:example-org:repositories:range:all',
+    ]);
+    assert.equal(invalidatedCount, 3);
 });

--- a/backend/test/repository_insights.test.js
+++ b/backend/test/repository_insights.test.js
@@ -1,0 +1,75 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    REPOSITORY_INSIGHTS_SQL,
+    mapRepositoryInsightRow,
+} = require('../repository_insights');
+
+test('repository insight query keeps inactive tracked repositories and counts unique contributors', () => {
+    assert.match(REPOSITORY_INSIGHTS_SQL, /JOIN eligible_repositories er ON er\.id = rs\.repo_id/);
+    assert.match(REPOSITORY_INSIGHTS_SQL, /LEFT JOIN snapshot_totals/);
+    assert.match(REPOSITORY_INSIGHTS_SQL, /COUNT\(DISTINCT cra\.contributor_id\)/);
+    assert.match(REPOSITORY_INSIGHTS_SQL, /r\.is_in_organization = TRUE/);
+    assert.match(REPOSITORY_INSIGHTS_SQL, /r\.sig_id IS NOT NULL/);
+});
+
+test('maps database values to a repository insight response', () => {
+    const result = mapRepositoryInsightRow({
+        id: '7',
+        name: 'demo repo',
+        sig_id: '2',
+        sig_name: '基础设施 SIG',
+        new_prs: '3',
+        closed_merged_prs: '2',
+        new_issues: '4',
+        closed_issues: '1',
+        new_commits: '9',
+        active_contributors: '5',
+        lines_added: '120',
+        lines_deleted: '30',
+        last_active_date: new Date('2026-09-05T00:00:00.000Z'),
+    }, 'example-org');
+
+    assert.deepEqual(result, {
+        id: 7,
+        name: 'demo repo',
+        url: 'https://github.com/example-org/demo%20repo',
+        sig: { id: 2, name: '基础设施 SIG' },
+        new_prs: 3,
+        closed_merged_prs: 2,
+        new_issues: 4,
+        closed_issues: 1,
+        new_commits: 9,
+        active_contributors: 5,
+        lines_added: 120,
+        lines_deleted: 30,
+        is_active: true,
+        last_active_date: '2026-09-05',
+    });
+});
+
+test('marks a repository without activity in the selected range as inactive', () => {
+    const result = mapRepositoryInsightRow({
+        id: 8,
+        name: 'quiet',
+        sig_id: 3,
+        sig_name: '文档 SIG',
+    }, 'example-org');
+
+    assert.equal(result.is_active, false);
+    assert.equal(result.last_active_date, null);
+    assert.equal(result.active_contributors, 0);
+});
+
+test('does not classify code-line totals without a PR, issue, or commit as repository activity', () => {
+    const result = mapRepositoryInsightRow({
+        id: 9,
+        name: 'line-only',
+        sig_id: 3,
+        sig_name: '文档 SIG',
+        lines_added: 12,
+    }, 'example-org');
+
+    assert.equal(result.is_active, false);
+});

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -18,6 +18,7 @@ import ContributorLeaderboard from './ContributorLeaderboard';
 import ContributorStats from './ContributorStats';
 import DayDetailModal from './DayDetailModal';
 import SIGContributorModal from './SIGContributorModal';
+import RepositoryInsights from './RepositoryInsights';
 import { useToast, ToastContainer } from './Toast';
 
 const Dashboard = () => {
@@ -32,6 +33,7 @@ const Dashboard = () => {
     const [growthLoading, setGrowthLoading] = useState(false);
     const [selectedSigIds, setSelectedSigIds] = useState([]);
     const [comparisonData, setComparisonData] = useState([]);
+    const [repositoryRefreshToken, setRepositoryRefreshToken] = useState(0);
     const { toasts, addToast, removeToast } = useToast();
 
     // Modal states
@@ -145,6 +147,7 @@ const Dashboard = () => {
 
     const handleRefresh = () => {
         addToast('正在刷新数据...', 'info', 1000);
+        setRepositoryRefreshToken((current) => current + 1);
         fetchAllData();
     };
 
@@ -389,6 +392,9 @@ const Dashboard = () => {
                     />
                 </div>
             </div>
+
+            {/* Repository-level analysis follows the SIG overview */}
+            <RepositoryInsights range={range} sigs={allSigs} refreshToken={repositoryRefreshToken} />
 
             {/* Contributor Section */}
             <div className="mb-8">

--- a/frontend/src/components/RepositoryInsights.jsx
+++ b/frontend/src/components/RepositoryInsights.jsx
@@ -1,0 +1,369 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import ReactECharts from 'echarts-for-react';
+import * as echarts from 'echarts';
+import { getRepositoryInsights } from '../services/api';
+
+const METRICS = [
+    { key: 'pr_activity', label: 'PR', color: '#8b5cf6' },
+    { key: 'issue_activity', label: 'Issue', color: '#f59e0b' },
+    { key: 'new_commits', label: 'Commit', color: '#10b981' },
+    { key: 'active_contributors', label: '活跃贡献者', color: '#ec4899' },
+];
+
+const TABLE_COLUMNS = [
+    { key: 'name', label: '仓库' },
+    { key: 'sig_name', label: '所属 SIG' },
+    { key: 'pr_activity', label: 'PR（新建/关闭）' },
+    { key: 'issue_activity', label: 'Issue（新建/关闭）' },
+    { key: 'new_commits', label: 'Commit' },
+    { key: 'active_contributors', label: '贡献者' },
+    { key: 'last_active_date', label: '最近活跃' },
+];
+
+const formatNumber = (value) => Number(value || 0).toLocaleString();
+
+const getRepositoryValue = (repository, key) => {
+    if (key === 'sig_name') return repository.sig.name;
+    if (key === 'pr_activity') return repository.new_prs + repository.closed_merged_prs;
+    if (key === 'issue_activity') return repository.new_issues + repository.closed_issues;
+    return repository[key];
+};
+
+const RepositoryInsights = ({ range, sigs, refreshToken = 0 }) => {
+    const [repositories, setRepositories] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+    const [selectedSigId, setSelectedSigId] = useState('all');
+    const [metric, setMetric] = useState('new_commits');
+    const [query, setQuery] = useState('');
+    const [sort, setSort] = useState({ key: 'new_commits', direction: 'desc' });
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const loadRepositories = async () => {
+            setLoading(true);
+            setError('');
+            try {
+                const data = await getRepositoryInsights(range);
+                if (!cancelled) {
+                    setRepositories(data.repositories || []);
+                }
+            } catch (requestError) {
+                if (!cancelled) {
+                    setError(requestError.response?.data?.error || '仓库数据加载失败');
+                }
+            } finally {
+                if (!cancelled) {
+                    setLoading(false);
+                }
+            }
+        };
+
+        loadRepositories();
+        return () => {
+            cancelled = true;
+        };
+    }, [range, refreshToken]);
+
+    const sigFilteredRepositories = useMemo(() => {
+        if (selectedSigId === 'all') {
+            return repositories;
+        }
+        return repositories.filter((repository) => String(repository.sig.id) === selectedSigId);
+    }, [repositories, selectedSigId]);
+
+    const activeRepositories = useMemo(
+        () => sigFilteredRepositories.filter((repository) => repository.is_active),
+        [sigFilteredRepositories],
+    );
+
+    const tableRepositories = useMemo(() => {
+        const normalizedQuery = query.trim().toLocaleLowerCase();
+        const filtered = normalizedQuery
+            ? activeRepositories.filter((repository) =>
+                repository.name.toLocaleLowerCase().includes(normalizedQuery)
+                || repository.sig.name.toLocaleLowerCase().includes(normalizedQuery))
+            : activeRepositories;
+
+        return [...filtered].sort((left, right) => {
+            const leftValue = getRepositoryValue(left, sort.key);
+            const rightValue = getRepositoryValue(right, sort.key);
+
+            const leftIsMissing = leftValue === null || leftValue === undefined;
+            const rightIsMissing = rightValue === null || rightValue === undefined;
+            if (leftIsMissing && rightIsMissing) return 0;
+            if (leftIsMissing) return 1;
+            if (rightIsMissing) return -1;
+
+            const comparison = typeof leftValue === 'number'
+                ? leftValue - rightValue
+                : String(leftValue).localeCompare(String(rightValue), 'zh-CN');
+            return sort.direction === 'asc' ? comparison : -comparison;
+        });
+    }, [activeRepositories, query, sort]);
+
+    const metricDefinition = METRICS.find((item) => item.key === metric);
+    const topRepositories = useMemo(
+        () => [...activeRepositories]
+            .sort((left, right) => getRepositoryValue(right, metric) - getRepositoryValue(left, metric))
+            .slice(0, 10),
+        [activeRepositories, metric],
+    );
+    const activeCount = activeRepositories.length;
+    const inactiveCount = sigFilteredRepositories.length - activeCount;
+
+    const barOption = {
+        backgroundColor: 'transparent',
+        tooltip: {
+            trigger: 'axis',
+            axisPointer: { type: 'shadow' },
+            backgroundColor: 'rgba(17, 24, 39, 0.95)',
+            borderColor: '#374151',
+            textStyle: { color: '#f3f4f6' },
+        },
+        grid: { left: 12, right: 28, top: 16, bottom: 8, containLabel: true },
+        xAxis: {
+            type: 'value',
+            minInterval: 1,
+            splitLine: { lineStyle: { color: '#374151', type: 'dashed' } },
+            axisLabel: { color: '#9ca3af' },
+        },
+        yAxis: {
+            type: 'category',
+            inverse: true,
+            data: topRepositories.map((repository) => repository.name),
+            axisLabel: { color: '#d1d5db', width: 130, overflow: 'truncate' },
+            axisLine: { lineStyle: { color: '#4b5563' } },
+        },
+        series: [{
+            name: metricDefinition.label,
+            type: 'bar',
+            data: topRepositories.map((repository) => getRepositoryValue(repository, metric)),
+            barMaxWidth: 22,
+            label: { show: true, position: 'right', color: '#e5e7eb' },
+            itemStyle: {
+                borderRadius: [0, 5, 5, 0],
+                color: new echarts.graphic.LinearGradient(0, 0, 1, 0, [
+                    { offset: 0, color: metricDefinition.color },
+                    { offset: 1, color: '#60a5fa' },
+                ]),
+            },
+        }],
+    };
+
+    const pieOption = {
+        backgroundColor: 'transparent',
+        tooltip: {
+            trigger: 'item',
+            formatter: '{b}: {c} 个 ({d}%)',
+            backgroundColor: 'rgba(17, 24, 39, 0.95)',
+            borderColor: '#374151',
+            textStyle: { color: '#f3f4f6' },
+        },
+        legend: {
+            bottom: 0,
+            textStyle: { color: '#d1d5db' },
+        },
+        graphic: sigFilteredRepositories.length > 0 ? [{
+            type: 'text',
+            left: 'center',
+            top: '42%',
+            style: {
+                text: `${activeCount}/${sigFilteredRepositories.length}`,
+                fill: '#f9fafb',
+                fontSize: 24,
+                fontWeight: 700,
+                textAlign: 'center',
+            },
+        }, {
+            type: 'text',
+            left: 'center',
+            top: '51%',
+            style: {
+                text: '活跃仓库',
+                fill: '#9ca3af',
+                fontSize: 12,
+                textAlign: 'center',
+            },
+        }] : [],
+        series: [{
+            type: 'pie',
+            radius: ['52%', '72%'],
+            center: ['50%', '45%'],
+            avoidLabelOverlap: true,
+            label: { color: '#d1d5db', formatter: '{b}\n{c} 个' },
+            itemStyle: { borderColor: '#1f2937', borderWidth: 3 },
+            data: [
+                { value: activeCount, name: '有活动', itemStyle: { color: '#10b981' } },
+                { value: inactiveCount, name: '无活动', itemStyle: { color: '#4b5563' } },
+            ],
+        }],
+    };
+
+    const changeSort = (key) => {
+        setSort((current) => ({
+            key,
+            direction: current.key === key && current.direction === 'desc' ? 'asc' : 'desc',
+        }));
+    };
+
+    if (loading) {
+        return (
+            <section className="mb-8" aria-busy="true">
+                <div className="mb-6 h-8 w-40 animate-pulse rounded bg-gray-700" />
+                <div className="grid gap-8 lg:grid-cols-3">
+                    <div className="h-96 animate-pulse rounded-xl bg-gray-800 lg:col-span-2" />
+                    <div className="h-96 animate-pulse rounded-xl bg-gray-800" />
+                </div>
+            </section>
+        );
+    }
+
+    return (
+        <section className="mb-8" aria-labelledby="repository-insights-title">
+            <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+                <div>
+                    <h2 id="repository-insights-title" className="text-2xl font-bold text-white">仓库洞察</h2>
+                    <p className="mt-1 text-sm text-gray-400">从 SIG 下钻到具体项目，数据范围与页面顶部选择保持一致。</p>
+                </div>
+                <label className="flex items-center gap-2 text-sm text-gray-300">
+                    <span>筛选 SIG</span>
+                    <select
+                        value={selectedSigId}
+                        onChange={(event) => setSelectedSigId(event.target.value)}
+                        className="rounded-lg border border-gray-600 bg-gray-800 px-3 py-2 text-white outline-none focus:border-blue-500"
+                    >
+                        <option value="all">全部 SIG</option>
+                        {sigs.map((sig) => <option key={sig.id} value={String(sig.id)}>{sig.name}</option>)}
+                    </select>
+                </label>
+            </div>
+
+            {error ? (
+                <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-6 text-red-200">{error}</div>
+            ) : (
+                <>
+                    <div className="mb-8 grid gap-8 lg:grid-cols-3">
+                        <div className="flex h-[28rem] flex-col rounded-xl border border-gray-700 bg-gray-800 p-6 shadow-xl lg:col-span-2">
+                            <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                <div>
+                                    <h3 className="font-semibold text-white">活跃仓库 Top 10</h3>
+                                    <p className="mt-1 text-xs text-gray-400">按所选指标统计当前时间范围内的活跃仓库</p>
+                                </div>
+                                <div className="flex flex-wrap gap-2" aria-label="仓库排行指标">
+                                    {METRICS.map((item) => (
+                                        <button
+                                            key={item.key}
+                                            type="button"
+                                            onClick={() => {
+                                                setMetric(item.key);
+                                                setSort({ key: item.key, direction: 'desc' });
+                                            }}
+                                            className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${metric === item.key
+                                                ? 'bg-blue-600 text-white'
+                                                : 'bg-gray-700 text-gray-300 hover:bg-gray-600'}`}
+                                        >
+                                            {item.label}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                            <div className="min-h-0 flex-1">
+                                {topRepositories.length > 0
+                                    ? <ReactECharts option={barOption} style={{ height: '100%', width: '100%' }} />
+                                    : <EmptyState />}
+                            </div>
+                        </div>
+
+                        <div className="flex h-[28rem] flex-col rounded-xl border border-gray-700 bg-gray-800 p-6 shadow-xl">
+                            <div>
+                                <h3 className="font-semibold text-white">活跃仓库占比</h3>
+                                <p className="mt-1 text-xs text-gray-400">有 PR、Issue 或 Commit 的仓库视为活跃</p>
+                            </div>
+                            <div className="min-h-0 flex-1">
+                                {sigFilteredRepositories.length > 0
+                                    ? <ReactECharts option={pieOption} style={{ height: '100%', width: '100%' }} />
+                                    : <EmptyState />}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="overflow-hidden rounded-xl border border-gray-700 bg-gray-800 shadow-xl">
+                        <div className="flex flex-col gap-3 border-b border-gray-700 p-5 sm:flex-row sm:items-center sm:justify-between">
+                            <div>
+                                <h3 className="font-semibold text-white">仓库明细</h3>
+                                <p className="mt-1 text-xs text-gray-400">
+                                    当前时间范围内共 {activeRepositories.length} 个活跃仓库
+                                    {query.trim() && `，其中 ${tableRepositories.length} 个匹配搜索`}
+                                    ，可点击表头排序
+                                </p>
+                            </div>
+                            <label className="relative">
+                                <span className="sr-only">搜索仓库或 SIG</span>
+                                <input
+                                    type="search"
+                                    value={query}
+                                    onChange={(event) => setQuery(event.target.value)}
+                                    placeholder="搜索仓库或 SIG"
+                                    className="w-full rounded-lg border border-gray-600 bg-gray-900 px-3 py-2 text-sm text-white outline-none placeholder:text-gray-500 focus:border-blue-500 sm:w-64"
+                                />
+                            </label>
+                        </div>
+                        <div className="overflow-x-auto">
+                            <table className="min-w-full divide-y divide-gray-700 text-sm">
+                                <thead className="bg-gray-900/50">
+                                    <tr>
+                                        {TABLE_COLUMNS.map((column) => (
+                                            <th key={column.key} scope="col" className="whitespace-nowrap px-4 py-3 text-left font-medium text-gray-400">
+                                                <button type="button" onClick={() => changeSort(column.key)} className="inline-flex items-center gap-1 hover:text-white">
+                                                    {column.label}
+                                                    {sort.key === column.key && <span aria-hidden="true">{sort.direction === 'desc' ? '↓' : '↑'}</span>}
+                                                </button>
+                                            </th>
+                                        ))}
+                                        <th scope="col" className="px-4 py-3 text-left font-medium text-gray-400">状态</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-gray-700/70">
+                                    {tableRepositories.map((repository) => (
+                                        <tr key={repository.id} className="hover:bg-gray-700/30">
+                                            <td className="whitespace-nowrap px-4 py-3 font-medium">
+                                                <a href={repository.url} target="_blank" rel="noreferrer" className="text-blue-300 hover:text-blue-200 hover:underline">
+                                                    {repository.name} ↗
+                                                </a>
+                                            </td>
+                                            <td className="whitespace-nowrap px-4 py-3 text-gray-300">{repository.sig.name}</td>
+                                            <td className="whitespace-nowrap px-4 py-3 text-gray-200">{formatNumber(repository.new_prs)} / {formatNumber(repository.closed_merged_prs)}</td>
+                                            <td className="whitespace-nowrap px-4 py-3 text-gray-200">{formatNumber(repository.new_issues)} / {formatNumber(repository.closed_issues)}</td>
+                                            <td className="px-4 py-3 text-gray-200">{formatNumber(repository.new_commits)}</td>
+                                            <td className="px-4 py-3 text-gray-200">{formatNumber(repository.active_contributors)}</td>
+                                            <td className="whitespace-nowrap px-4 py-3 text-gray-400">{repository.last_active_date || '—'}</td>
+                                            <td className="px-4 py-3">
+                                                <span className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${repository.is_active
+                                                    ? 'bg-emerald-400/10 text-emerald-300'
+                                                    : 'bg-gray-600/30 text-gray-400'}`}
+                                                >
+                                                    {repository.is_active ? '活跃' : '无活动'}
+                                                </span>
+                                            </td>
+                                        </tr>
+                                    ))}
+                                    {tableRepositories.length === 0 && (
+                                        <tr><td colSpan={8}><EmptyState /></td></tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </>
+            )}
+        </section>
+    );
+};
+
+const EmptyState = () => (
+    <div className="flex h-full min-h-32 items-center justify-center p-6 text-sm text-gray-500">当前条件下暂无仓库数据</div>
+);
+
+export default RepositoryInsights;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -38,6 +38,16 @@ export const getOrgSigs = async () => {
     }
 };
 
+export const getRepositoryInsights = async (range = '30d') => {
+    try {
+        const response = await api.get('/organization/repositories', { params: { range } });
+        return response.data;
+    } catch (error) {
+        console.error('Error fetching repository insights:', error);
+        throw error;
+    }
+};
+
 export const getSigTimeseries = async (sigId, range = '30d') => {
     try {
         const response = await api.get(`/sig/${sigId}/timeseries`, { params: { range } });
@@ -175,4 +185,3 @@ export const getSigContributors = async (sigId, range = '30d') => {
 };
 
 export default api;
-


### PR DESCRIPTION
## Summary

- add a cached repository-level activity API with SIG attribution and human contributor counts
- add active repository Top 10 and active/inactive distribution charts after the SIG overview
- add an active-only repository detail table with SIG filtering, search, combined PR/Issue sorting, and GitHub links
- keep repository filtering independent from contributor analysis

## Testing

- backend: npm test (37 passed)
- frontend: npm run build
- frontend: targeted ESLint for RepositoryInsights.jsx, Dashboard.jsx, and api.js
- isolated tcloud candidate deployment with real data and desktop/mobile browser verification