### PR TITLE
feat: show dashboard data freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ psql -d oss_dashboard -f db/contributors_schema.sql
 ```bash
 psql -d oss_dashboard -f db/migrations/001_github_custom_property_sigs.sql
 psql -d oss_dashboard -f db/migrations/002_repository_organization_membership.sql
+psql -d oss_dashboard -f db/migrations/003_organization_ingestion_freshness.sql
 ```
 
 执行 `002` 后需启动后端或运行 `npm run sync-repository-sigs`，以 GitHub 当前仓库列表更新组织成员状态。

--- a/backend/data_freshness.js
+++ b/backend/data_freshness.js
@@ -1,5 +1,10 @@
 const DATA_FRESHNESS_THRESHOLD_MS = 12 * 60 * 60 * 1000;
 
+const RECORD_SUCCESSFUL_INGESTION_SQL = `UPDATE organizations
+SET last_ingestion_completed_at = NOW()
+WHERE id = $1
+RETURNING last_ingestion_completed_at`;
+
 function normalizeTimestamp(value) {
     if (!value) {
         return null;
@@ -25,8 +30,15 @@ function buildDataFreshness(lastUpdatedAt, now = new Date()) {
     };
 }
 
+async function recordSuccessfulIngestion(queryable, orgId) {
+    const result = await queryable.query(RECORD_SUCCESSFUL_INGESTION_SQL, [orgId]);
+    return normalizeTimestamp(result.rows[0]?.last_ingestion_completed_at);
+}
+
 module.exports = {
     DATA_FRESHNESS_THRESHOLD_MS,
+    RECORD_SUCCESSFUL_INGESTION_SQL,
     buildDataFreshness,
     normalizeTimestamp,
+    recordSuccessfulIngestion,
 };

--- a/backend/data_freshness.js
+++ b/backend/data_freshness.js
@@ -37,6 +37,14 @@ function withDataFreshness(summaryData, now = new Date()) {
     };
 }
 
+function buildOrganizationSummaryCacheKey(organizationName, range, lastUpdatedAt) {
+    const normalizedTimestamp = normalizeTimestamp(lastUpdatedAt);
+    const generation = normalizedTimestamp
+        ? String(new Date(normalizedTimestamp).getTime())
+        : 'missing';
+    return `org:${organizationName}:summary:v4:generation:${generation}:range:${range}`;
+}
+
 async function recordSuccessfulIngestion(queryable, orgId) {
     const result = await queryable.query(RECORD_SUCCESSFUL_INGESTION_SQL, [orgId]);
     return normalizeTimestamp(result.rows[0]?.last_ingestion_completed_at);
@@ -61,6 +69,7 @@ async function invalidateOrganizationSummaryCache(redisClient, organizationName)
 module.exports = {
     DATA_FRESHNESS_THRESHOLD_MS,
     RECORD_SUCCESSFUL_INGESTION_SQL,
+    buildOrganizationSummaryCacheKey,
     buildDataFreshness,
     invalidateOrganizationSummaryCache,
     normalizeTimestamp,

--- a/backend/data_freshness.js
+++ b/backend/data_freshness.js
@@ -30,6 +30,13 @@ function buildDataFreshness(lastUpdatedAt, now = new Date()) {
     };
 }
 
+function withDataFreshness(summaryData, now = new Date()) {
+    return {
+        ...summaryData,
+        ...buildDataFreshness(summaryData.last_updated_at, now),
+    };
+}
+
 async function recordSuccessfulIngestion(queryable, orgId) {
     const result = await queryable.query(RECORD_SUCCESSFUL_INGESTION_SQL, [orgId]);
     return normalizeTimestamp(result.rows[0]?.last_ingestion_completed_at);
@@ -58,4 +65,5 @@ module.exports = {
     invalidateOrganizationSummaryCache,
     normalizeTimestamp,
     recordSuccessfulIngestion,
+    withDataFreshness,
 };

--- a/backend/data_freshness.js
+++ b/backend/data_freshness.js
@@ -1,0 +1,32 @@
+const DATA_FRESHNESS_THRESHOLD_MS = 12 * 60 * 60 * 1000;
+
+function normalizeTimestamp(value) {
+    if (!value) {
+        return null;
+    }
+
+    const timestamp = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(timestamp.getTime()) ? null : timestamp.toISOString();
+}
+
+function buildDataFreshness(lastUpdatedAt, now = new Date()) {
+    const normalizedTimestamp = normalizeTimestamp(lastUpdatedAt);
+    if (!normalizedTimestamp) {
+        return {
+            last_updated_at: null,
+            data_status: 'missing',
+        };
+    }
+
+    const ageMs = now.getTime() - new Date(normalizedTimestamp).getTime();
+    return {
+        last_updated_at: normalizedTimestamp,
+        data_status: ageMs > DATA_FRESHNESS_THRESHOLD_MS ? 'stale' : 'fresh',
+    };
+}
+
+module.exports = {
+    DATA_FRESHNESS_THRESHOLD_MS,
+    buildDataFreshness,
+    normalizeTimestamp,
+};

--- a/backend/data_freshness.js
+++ b/backend/data_freshness.js
@@ -35,10 +35,27 @@ async function recordSuccessfulIngestion(queryable, orgId) {
     return normalizeTimestamp(result.rows[0]?.last_ingestion_completed_at);
 }
 
+async function invalidateOrganizationSummaryCache(redisClient, organizationName) {
+    const cacheKeys = [];
+    for await (const key of redisClient.scanIterator({
+        MATCH: `org:${organizationName}:summary:*`,
+        COUNT: 100,
+    })) {
+        cacheKeys.push(key);
+    }
+
+    if (cacheKeys.length > 0) {
+        await redisClient.del(cacheKeys);
+    }
+
+    return cacheKeys.length;
+}
+
 module.exports = {
     DATA_FRESHNESS_THRESHOLD_MS,
     RECORD_SUCCESSFUL_INGESTION_SQL,
     buildDataFreshness,
+    invalidateOrganizationSummaryCache,
     normalizeTimestamp,
     recordSuccessfulIngestion,
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -37,9 +37,10 @@ const {
     mapRepositoryInsightRows,
 } = require('./repository_insights');
 const {
-    buildDataFreshness,
     invalidateOrganizationSummaryCache,
+    normalizeTimestamp,
     recordSuccessfulIngestion,
+    withDataFreshness,
 } = require('./data_freshness');
 
 const app = express();
@@ -1444,7 +1445,7 @@ app.get('/api/v1/organization/summary', async (req, res) => {
         const cachedData = await redisClient.get(cacheKey);
         if (cachedData) {
             console.log(`Cache hit for summary: ${cacheKey}`);
-            return res.json(JSON.parse(cachedData));
+            return res.json(withDataFreshness(JSON.parse(cachedData)));
         }
         console.log(`Cache miss for summary: ${cacheKey}. Querying DB...`);
 
@@ -1497,14 +1498,14 @@ app.get('/api/v1/organization/summary', async (req, res) => {
             active_contributors: parseInt(contributorCountResult.rows[0].unique_contributors, 10),
             days_counted: parseInt(summaryResult.rows[0].days_counted, 10),
             range_days: days, // 在响应中包含请求的范围
-            ...buildDataFreshness(summaryResult.rows[0].last_updated_at),
+            last_updated_at: normalizeTimestamp(summaryResult.rows[0].last_updated_at),
         };
 
         // 4. 存入缓存并返回
         await redisClient.setEx(cacheKey, cacheTTL, JSON.stringify(summaryData));
         console.log(`Summary data stored in cache for ${cacheKey}.`);
 
-        res.json(summaryData);
+        res.json(withDataFreshness(summaryData));
 
     } catch (error) {
         console.error(`Error fetching summary data for organization:`, error.message);

--- a/backend/server.js
+++ b/backend/server.js
@@ -36,7 +36,7 @@ const {
     invalidateRepositoryInsightCache,
     mapRepositoryInsightRows,
 } = require('./repository_insights');
-const { buildDataFreshness } = require('./data_freshness');
+const { buildDataFreshness, recordSuccessfulIngestion } = require('./data_freshness');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -939,6 +939,8 @@ async function runDailyIngestionJob() {
         console.log(`[aggregation] organization@${targetDateStr}: saved snapshot (id=${result.rows[0].id})`);
         console.log(`Successfully stored organization snapshot for ${ORG_NAME} on ${targetDateStr}.`);
 
+        await recordSuccessfulIngestion(pool, org.id);
+
         console.log('--- Daily Data Ingestion Job Finished Successfully ---');
 
         // 主动刷新缓存
@@ -1423,7 +1425,7 @@ app.get('/api/v1/organization/timeseries', async (req, res) => {
 app.get('/api/v1/organization/summary', async (req, res) => {
     // 默认30天，允许通过查询参数更改，例如 /summary?range=7d
     const range = req.query.range || '30d';
-    const cacheKey = `org:${ORG_NAME}:summary:v2:range:${range}`;
+    const cacheKey = `org:${ORG_NAME}:summary:v3:range:${range}`;
     const cacheTTL = 60 * 10; // 缓存10分钟
 
     try {
@@ -1456,8 +1458,8 @@ app.get('/api/v1/organization/summary', async (req, res) => {
                  WHERE org_id = $1 AND is_in_organization = TRUE) as organization_repositories,
                 (SELECT COUNT(*) FROM repositories
                  WHERE org_id = $1 AND is_in_organization = TRUE AND sig_id IS NOT NULL) as tracked_repositories,
-                (SELECT MAX(freshness.created_at) FROM activity_snapshots freshness
-                 WHERE freshness.org_id = $1) as last_updated_at,
+                (SELECT freshness.last_ingestion_completed_at FROM organizations freshness
+                 WHERE freshness.id = $1) as last_updated_at,
                 -- 为了调试和验证，可以返回统计了多少天的数据
                 COUNT(*) as days_counted 
              FROM activity_snapshots

--- a/backend/server.js
+++ b/backend/server.js
@@ -36,6 +36,7 @@ const {
     invalidateRepositoryInsightCache,
     mapRepositoryInsightRows,
 } = require('./repository_insights');
+const { buildDataFreshness } = require('./data_freshness');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -1422,7 +1423,7 @@ app.get('/api/v1/organization/timeseries', async (req, res) => {
 app.get('/api/v1/organization/summary', async (req, res) => {
     // 默认30天，允许通过查询参数更改，例如 /summary?range=7d
     const range = req.query.range || '30d';
-    const cacheKey = `org:${ORG_NAME}:summary:range:${range}`;
+    const cacheKey = `org:${ORG_NAME}:summary:v2:range:${range}`;
     const cacheTTL = 60 * 10; // 缓存10分钟
 
     try {
@@ -1455,6 +1456,8 @@ app.get('/api/v1/organization/summary', async (req, res) => {
                  WHERE org_id = $1 AND is_in_organization = TRUE) as organization_repositories,
                 (SELECT COUNT(*) FROM repositories
                  WHERE org_id = $1 AND is_in_organization = TRUE AND sig_id IS NOT NULL) as tracked_repositories,
+                (SELECT MAX(freshness.created_at) FROM activity_snapshots freshness
+                 WHERE freshness.org_id = $1) as last_updated_at,
                 -- 为了调试和验证，可以返回统计了多少天的数据
                 COUNT(*) as days_counted 
              FROM activity_snapshots
@@ -1486,6 +1489,7 @@ app.get('/api/v1/organization/summary', async (req, res) => {
             active_contributors: parseInt(contributorCountResult.rows[0].unique_contributors, 10),
             days_counted: parseInt(summaryResult.rows[0].days_counted, 10),
             range_days: days, // 在响应中包含请求的范围
+            ...buildDataFreshness(summaryResult.rows[0].last_updated_at),
         };
 
         // 4. 存入缓存并返回

--- a/backend/server.js
+++ b/backend/server.js
@@ -37,6 +37,7 @@ const {
     mapRepositoryInsightRows,
 } = require('./repository_insights');
 const {
+    buildOrganizationSummaryCacheKey,
     invalidateOrganizationSummaryCache,
     normalizeTimestamp,
     recordSuccessfulIngestion,
@@ -1331,7 +1332,10 @@ cron.schedule('0 */6 * * *', runDailyIngestionJob); // Every 6 hours for testing
 
 // Helper function for security check (now simplified for single org)
 async function getMonitoredOrg() {
-    const orgResult = await pool.query("SELECT id, name FROM organizations WHERE name = $1", [ORG_NAME]);
+    const orgResult = await pool.query(
+        "SELECT id, name, last_ingestion_completed_at FROM organizations WHERE name = $1",
+        [ORG_NAME],
+    );
     return orgResult.rows[0];
 }
 
@@ -1432,7 +1436,6 @@ app.get('/api/v1/organization/timeseries', async (req, res) => {
 app.get('/api/v1/organization/summary', async (req, res) => {
     // 默认30天，允许通过查询参数更改，例如 /summary?range=7d
     const range = req.query.range || '30d';
-    const cacheKey = `org:${ORG_NAME}:summary:v3:range:${range}`;
     const cacheTTL = 60 * 10; // 缓存10分钟
 
     try {
@@ -1440,6 +1443,11 @@ app.get('/api/v1/organization/summary', async (req, res) => {
         if (!org) {
             return res.status(404).json({ error: 'Monitored organization not found.' });
         }
+        const cacheKey = buildOrganizationSummaryCacheKey(
+            ORG_NAME,
+            range,
+            org.last_ingestion_completed_at,
+        );
 
         // 1. 检查缓存
         const cachedData = await redisClient.get(cacheKey);
@@ -1465,8 +1473,6 @@ app.get('/api/v1/organization/summary', async (req, res) => {
                  WHERE org_id = $1 AND is_in_organization = TRUE) as organization_repositories,
                 (SELECT COUNT(*) FROM repositories
                  WHERE org_id = $1 AND is_in_organization = TRUE AND sig_id IS NOT NULL) as tracked_repositories,
-                (SELECT freshness.last_ingestion_completed_at FROM organizations freshness
-                 WHERE freshness.id = $1) as last_updated_at,
                 -- 为了调试和验证，可以返回统计了多少天的数据
                 COUNT(*) as days_counted 
              FROM activity_snapshots
@@ -1498,7 +1504,7 @@ app.get('/api/v1/organization/summary', async (req, res) => {
             active_contributors: parseInt(contributorCountResult.rows[0].unique_contributors, 10),
             days_counted: parseInt(summaryResult.rows[0].days_counted, 10),
             range_days: days, // 在响应中包含请求的范围
-            last_updated_at: normalizeTimestamp(summaryResult.rows[0].last_updated_at),
+            last_updated_at: normalizeTimestamp(org.last_ingestion_completed_at),
         };
 
         // 4. 存入缓存并返回

--- a/backend/server.js
+++ b/backend/server.js
@@ -36,7 +36,11 @@ const {
     invalidateRepositoryInsightCache,
     mapRepositoryInsightRows,
 } = require('./repository_insights');
-const { buildDataFreshness, recordSuccessfulIngestion } = require('./data_freshness');
+const {
+    buildDataFreshness,
+    invalidateOrganizationSummaryCache,
+    recordSuccessfulIngestion,
+} = require('./data_freshness');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -940,6 +944,8 @@ async function runDailyIngestionJob() {
         console.log(`Successfully stored organization snapshot for ${ORG_NAME} on ${targetDateStr}.`);
 
         await recordSuccessfulIngestion(pool, org.id);
+        const invalidatedSummaryCacheKeys = await invalidateOrganizationSummaryCache(redisClient, ORG_NAME);
+        console.log(`Invalidated ${invalidatedSummaryCacheKeys} organization summary cache keys.`);
 
         console.log('--- Daily Data Ingestion Job Finished Successfully ---');
 

--- a/backend/test/data_freshness.test.js
+++ b/backend/test/data_freshness.test.js
@@ -1,0 +1,46 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    DATA_FRESHNESS_THRESHOLD_MS,
+    buildDataFreshness,
+    normalizeTimestamp,
+} = require('../data_freshness');
+
+test('normalizes a valid data update time to ISO 8601', () => {
+    assert.equal(
+        normalizeTimestamp('2026-09-08T03:30:00+08:00'),
+        '2026-09-07T19:30:00.000Z',
+    );
+});
+
+test('returns a missing state when no valid data update time exists', () => {
+    assert.deepEqual(buildDataFreshness(null), {
+        last_updated_at: null,
+        data_status: 'missing',
+    });
+    assert.deepEqual(buildDataFreshness('not-a-date'), {
+        last_updated_at: null,
+        data_status: 'missing',
+    });
+});
+
+test('marks data at the twelve-hour threshold as fresh', () => {
+    const now = new Date('2026-09-08T12:00:00.000Z');
+    const updatedAt = new Date(now.getTime() - DATA_FRESHNESS_THRESHOLD_MS);
+
+    assert.deepEqual(buildDataFreshness(updatedAt, now), {
+        last_updated_at: updatedAt.toISOString(),
+        data_status: 'fresh',
+    });
+});
+
+test('marks data older than twelve hours as stale', () => {
+    const now = new Date('2026-09-08T12:00:00.000Z');
+    const updatedAt = new Date(now.getTime() - DATA_FRESHNESS_THRESHOLD_MS - 1);
+
+    assert.deepEqual(buildDataFreshness(updatedAt, now), {
+        last_updated_at: updatedAt.toISOString(),
+        data_status: 'stale',
+    });
+});

--- a/backend/test/data_freshness.test.js
+++ b/backend/test/data_freshness.test.js
@@ -3,8 +3,10 @@ const assert = require('node:assert/strict');
 
 const {
     DATA_FRESHNESS_THRESHOLD_MS,
+    RECORD_SUCCESSFUL_INGESTION_SQL,
     buildDataFreshness,
     normalizeTimestamp,
+    recordSuccessfulIngestion,
 } = require('../data_freshness');
 
 test('normalizes a valid data update time to ISO 8601', () => {
@@ -43,4 +45,34 @@ test('marks data older than twelve hours as stale', () => {
         last_updated_at: updatedAt.toISOString(),
         data_status: 'stale',
     });
+});
+
+test('records freshness only through the successful ingestion marker', async () => {
+    const calls = [];
+    const queryable = {
+        async query(sql, params) {
+            calls.push({ sql, params });
+            return { rows: [{ last_ingestion_completed_at: new Date('2026-09-08T06:00:00.000Z') }] };
+        },
+    };
+
+    assert.equal(
+        await recordSuccessfulIngestion(queryable, 42),
+        '2026-09-08T06:00:00.000Z',
+    );
+    assert.deepEqual(calls, [{
+        sql: RECORD_SUCCESSFUL_INGESTION_SQL,
+        params: [42],
+    }]);
+});
+
+test('propagates failures while recording successful ingestion', async () => {
+    const expectedError = new Error('write failed');
+    const queryable = {
+        async query() {
+            throw expectedError;
+        },
+    };
+
+    await assert.rejects(recordSuccessfulIngestion(queryable, 42), expectedError);
 });

--- a/backend/test/data_freshness.test.js
+++ b/backend/test/data_freshness.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const {
     DATA_FRESHNESS_THRESHOLD_MS,
     RECORD_SUCCESSFUL_INGESTION_SQL,
+    buildOrganizationSummaryCacheKey,
     buildDataFreshness,
     invalidateOrganizationSummaryCache,
     normalizeTimestamp,
@@ -64,6 +65,23 @@ test('recomputes freshness for the same cached summary on every response', () =>
         'stale',
     );
     assert.equal(cachedSummary.data_status, undefined);
+});
+
+test('changes summary cache generation after successful ingestion', () => {
+    const missingKey = buildOrganizationSummaryCacheKey('example-org', '30d', null);
+    const oldKey = buildOrganizationSummaryCacheKey(
+        'example-org',
+        '30d',
+        '2026-09-08T00:00:00.000Z',
+    );
+    const newKey = buildOrganizationSummaryCacheKey(
+        'example-org',
+        '30d',
+        '2026-09-08T06:00:00.000Z',
+    );
+
+    assert.equal(missingKey, 'org:example-org:summary:v4:generation:missing:range:30d');
+    assert.notEqual(oldKey, newKey);
 });
 
 test('records freshness only through the successful ingestion marker', async () => {

--- a/backend/test/data_freshness.test.js
+++ b/backend/test/data_freshness.test.js
@@ -5,6 +5,7 @@ const {
     DATA_FRESHNESS_THRESHOLD_MS,
     RECORD_SUCCESSFUL_INGESTION_SQL,
     buildDataFreshness,
+    invalidateOrganizationSummaryCache,
     normalizeTimestamp,
     recordSuccessfulIngestion,
 } = require('../data_freshness');
@@ -75,4 +76,32 @@ test('propagates failures while recording successful ingestion', async () => {
     };
 
     await assert.rejects(recordSuccessfulIngestion(queryable, 42), expectedError);
+});
+
+test('invalidates every organization summary cache after ingestion', async () => {
+    const scannedOptions = [];
+    const deletedKeys = [];
+    const redisClient = {
+        async *scanIterator(options) {
+            scannedOptions.push(options);
+            yield 'org:example-org:summary:v2:range:7d';
+            yield 'org:example-org:summary:v3:range:30d';
+        },
+        async del(keys) {
+            deletedKeys.push(...keys);
+        },
+    };
+
+    assert.equal(
+        await invalidateOrganizationSummaryCache(redisClient, 'example-org'),
+        2,
+    );
+    assert.deepEqual(scannedOptions, [{
+        MATCH: 'org:example-org:summary:*',
+        COUNT: 100,
+    }]);
+    assert.deepEqual(deletedKeys, [
+        'org:example-org:summary:v2:range:7d',
+        'org:example-org:summary:v3:range:30d',
+    ]);
 });

--- a/backend/test/data_freshness.test.js
+++ b/backend/test/data_freshness.test.js
@@ -8,6 +8,7 @@ const {
     invalidateOrganizationSummaryCache,
     normalizeTimestamp,
     recordSuccessfulIngestion,
+    withDataFreshness,
 } = require('../data_freshness');
 
 test('normalizes a valid data update time to ISO 8601', () => {
@@ -46,6 +47,23 @@ test('marks data older than twelve hours as stale', () => {
         last_updated_at: updatedAt.toISOString(),
         data_status: 'stale',
     });
+});
+
+test('recomputes freshness for the same cached summary on every response', () => {
+    const cachedSummary = {
+        new_prs: 12,
+        last_updated_at: '2026-09-08T00:00:00.000Z',
+    };
+
+    assert.equal(
+        withDataFreshness(cachedSummary, new Date('2026-09-08T12:00:00.000Z')).data_status,
+        'fresh',
+    );
+    assert.equal(
+        withDataFreshness(cachedSummary, new Date('2026-09-08T12:00:00.001Z')).data_status,
+        'stale',
+    );
+    assert.equal(cachedSummary.data_status, undefined);
 });
 
 test('records freshness only through the successful ingestion marker', async () => {

--- a/db/migrations/003_organization_ingestion_freshness.sql
+++ b/db/migrations/003_organization_ingestion_freshness.sql
@@ -1,0 +1,10 @@
+\encoding UTF8
+\set ON_ERROR_STOP on
+SET client_encoding = 'UTF8';
+
+BEGIN;
+
+ALTER TABLE organizations
+ADD COLUMN IF NOT EXISTS last_ingestion_completed_at TIMESTAMPTZ;
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -6,7 +6,8 @@ SET client_encoding = 'UTF8';
 CREATE TABLE organizations (
     id SERIAL PRIMARY KEY,
     name VARCHAR(255) UNIQUE NOT NULL,
-    created_at TIMESTAMPTZ DEFAULT NOW()
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    last_ingestion_completed_at TIMESTAMPTZ
 );
 
 -- Table: special_interest_groups

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -239,6 +239,10 @@ const Dashboard = () => {
                         sigData={sigData}
                         timeseries={timeseries}
                     />
+                    <DataFreshness
+                        lastUpdatedAt={summary?.last_updated_at}
+                        status={summary?.data_status}
+                    />
                 </div>
             </div>
 
@@ -437,6 +441,44 @@ const ScopeStat = ({ label, value, unit }) => (
         </div>
     </div>
 );
+
+const DATA_UPDATED_AT_FORMATTER = new Intl.DateTimeFormat('zh-CN', {
+    timeZone: 'Asia/Shanghai',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+});
+
+const DataFreshness = ({ lastUpdatedAt, status }) => {
+    const timestamp = lastUpdatedAt ? new Date(lastUpdatedAt) : null;
+    const hasValidTimestamp = timestamp && !Number.isNaN(timestamp.getTime());
+    const displayTime = hasValidTimestamp ? DATA_UPDATED_AT_FORMATTER.format(timestamp) : null;
+    const isStale = status === 'stale';
+    const label = isStale ? '数据可能延迟，更新于' : '数据更新于';
+
+    return (
+        <div
+            className="flex w-full items-center justify-end gap-2 whitespace-nowrap text-xs text-gray-400"
+            title={displayTime ? `最近一次成功生成组织数据快照：${displayTime}（北京时间）` : '当前没有可用的数据更新时间'}
+        >
+            <span
+                className={`h-2 w-2 rounded-full ${displayTime ? (isStale ? 'bg-amber-400' : 'bg-emerald-400') : 'bg-gray-500'}`}
+                aria-hidden="true"
+            />
+            {displayTime ? (
+                <span>
+                    {label}{' '}
+                    <time dateTime={lastUpdatedAt} className={isStale ? 'text-amber-300' : 'text-gray-300'}>
+                        {displayTime}
+                    </time>
+                </span>
+            ) : <span>暂无数据更新时间</span>}
+        </div>
+    );
+};
 
 const SummaryCard = ({ title, value, icon, color, subtext }) => {
     const colorClasses = {

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -451,13 +451,30 @@ const DATA_UPDATED_AT_FORMATTER = new Intl.DateTimeFormat('zh-CN', {
     minute: '2-digit',
     hour12: false,
 });
+const DATA_FRESHNESS_THRESHOLD_MS = 12 * 60 * 60 * 1000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 const DataFreshness = ({ lastUpdatedAt, status }) => {
+    const [currentTime, setCurrentTime] = useState(() => Date.now());
     const timestamp = lastUpdatedAt ? new Date(lastUpdatedAt) : null;
     const hasValidTimestamp = timestamp && !Number.isNaN(timestamp.getTime());
     const displayTime = hasValidTimestamp ? DATA_UPDATED_AT_FORMATTER.format(timestamp) : null;
-    const isStale = status === 'stale';
+    const staleAt = hasValidTimestamp ? timestamp.getTime() + DATA_FRESHNESS_THRESHOLD_MS : null;
+    const isStale = status === 'stale' || (staleAt !== null && currentTime > staleAt);
     const label = isStale ? '数据可能延迟，更新于' : '数据更新于';
+
+    useEffect(() => {
+        if (staleAt === null || currentTime > staleAt) {
+            return undefined;
+        }
+
+        const timerId = window.setTimeout(
+            () => setCurrentTime(Date.now()),
+            Math.min(staleAt - Date.now() + 1, MAX_TIMER_DELAY_MS),
+        );
+
+        return () => window.clearTimeout(timerId);
+    }, [currentTime, staleAt]);
 
     return (
         <div


### PR DESCRIPTION
## Summary

- expose the latest organization activity snapshot timestamp in the summary API
- classify dashboard data as fresh, stale, or missing with a 12-hour threshold
- display the latest update time in the dashboard header with a compact status indicator
- add focused backend tests for timestamp normalization and freshness states

Part of #60.

## Verification

- `cd backend && npm test` (42 passed)
- `cd frontend && npm run build`
- `cd frontend && npx eslint src/components/Dashboard.jsx` (0 errors; 2 pre-existing Hook warnings)