### PR TITLE
fix: keep SIG comparison legend inside chart card

### DIFF
--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -337,15 +337,17 @@ const Dashboard = () => {
             </div>
 
             {/* Multi-SIG Comparison Chart */}
-            <div className="bg-gray-800 rounded-xl p-6 border border-gray-700 shadow-xl mb-8" style={{ height: '500px' }}>
-                <h3 className="text-lg font-semibold mb-4">多 SIG 趋势对比</h3>
-                <MultiSIGComparisonChart
-                    sigs={comparisonData}
-                    selectedSigIds={selectedSigIds}
-                    onSigSelectionChange={setSelectedSigIds}
-                    range={range}
-                    granularity={granularity}
-                />
+            <div className="flex h-[500px] flex-col rounded-xl border border-gray-700 bg-gray-800 p-6 shadow-xl mb-8">
+                <h3 className="mb-4 shrink-0 text-lg font-semibold">多 SIG 趋势对比</h3>
+                <div className="min-h-0 flex-1">
+                    <MultiSIGComparisonChart
+                        sigs={comparisonData}
+                        selectedSigIds={selectedSigIds}
+                        onSigSelectionChange={setSelectedSigIds}
+                        range={range}
+                        granularity={granularity}
+                    />
+                </div>
             </div>
 
             {/* Secondary Charts Grid */}


### PR DESCRIPTION
多 SIG 趋势对比的图表原先占满卡片内容高度，再加上标题高度后，底部 SIG 图例会溢出卡片。

将卡片改为纵向 flex 布局，标题保持固定高度，图表仅占剩余空间，使 SIG 图例保留在卡片方框内。卡片总高度仍为 500px。

验证：前端 `npm run build` 和 `git diff --check` 通过。本地预览未连接后端，尚未完成真实数据下的图例视觉验证。
