### PR TITLE
fix: align growth comparison periods

### DIFF
--- a/backend/growth_analysis.js
+++ b/backend/growth_analysis.js
@@ -106,9 +106,14 @@ function calculateGrowthMetrics(current, previous) {
     };
 }
 
+function hasCompletePeriodDates(period) {
+    return Boolean(period?.start && period?.end);
+}
+
 module.exports = {
     buildComparisonPeriods,
     calculateGrowthMetrics,
     formatGrowthMetrics,
     getRangeDays,
+    hasCompletePeriodDates,
 };

--- a/backend/growth_analysis.js
+++ b/backend/growth_analysis.js
@@ -47,6 +47,19 @@ function buildComparisonPeriods(range, firstSnapshotDate, latestSnapshotDate, sn
 
     const days = getRangeDays(range);
     if (days === null) {
+        if (availableDates) {
+            for (let date = firstDate || latestDate; date <= latestDate; date = addDays(date, 1)) {
+                if (!availableDates.has(date)) {
+                    return {
+                        comparison_available: false,
+                        reason: 'incomplete_current_period',
+                        current: { start: null, end: null },
+                        previous: null,
+                    };
+                }
+            }
+        }
+
         return {
             comparison_available: false,
             reason: 'unbounded_range',

--- a/backend/growth_analysis.js
+++ b/backend/growth_analysis.js
@@ -58,21 +58,32 @@ function buildComparisonPeriods(range, firstSnapshotDate, latestSnapshotDate, sn
     const currentStart = addDays(latestDate, -(days - 1));
     const previousEnd = addDays(currentStart, -1);
     const previousStart = addDays(previousEnd, -(days - 1));
+    const retainedCurrentStart = firstDate && firstDate > currentStart ? firstDate : currentStart;
+
+    if (availableDates) {
+        for (let date = retainedCurrentStart; date <= latestDate; date = addDays(date, 1)) {
+            if (!availableDates.has(date)) {
+                return {
+                    comparison_available: false,
+                    reason: 'incomplete_current_period',
+                    current: { start: null, end: null },
+                    previous: null,
+                };
+            }
+        }
+    }
 
     if (!firstDate || firstDate > previousStart) {
         return {
             comparison_available: false,
             reason: 'insufficient_history',
-            current: {
-                start: firstDate && firstDate > currentStart ? firstDate : currentStart,
-                end: latestDate,
-            },
+            current: { start: retainedCurrentStart, end: latestDate },
             previous: null,
         };
     }
 
     if (availableDates) {
-        for (let date = previousStart; date <= latestDate; date = addDays(date, 1)) {
+        for (let date = previousStart; date <= previousEnd; date = addDays(date, 1)) {
             if (!availableDates.has(date)) {
                 return {
                     comparison_available: false,

--- a/backend/growth_analysis.js
+++ b/backend/growth_analysis.js
@@ -45,6 +45,15 @@ function buildComparisonPeriods(range, firstSnapshotDate, latestSnapshotDate, sn
         };
     }
 
+    if (firstDate && firstDate > latestDate) {
+        return {
+            comparison_available: false,
+            reason: 'incomplete_current_period',
+            current: { start: null, end: null },
+            previous: null,
+        };
+    }
+
     const days = getRangeDays(range);
     if (days === null) {
         if (availableDates) {
@@ -147,7 +156,7 @@ function calculateGrowthMetrics(current, previous) {
 }
 
 function hasCompletePeriodDates(period) {
-    return Boolean(period?.start && period?.end);
+    return Boolean(period?.start && period?.end && period.start <= period.end);
 }
 
 module.exports = {

--- a/backend/growth_analysis.js
+++ b/backend/growth_analysis.js
@@ -56,6 +56,18 @@ function buildComparisonPeriods(range, firstSnapshotDate, latestSnapshotDate) {
     const previousEnd = addDays(currentStart, -1);
     const previousStart = addDays(previousEnd, -(days - 1));
 
+    if (!firstDate || firstDate > previousStart) {
+        return {
+            comparison_available: false,
+            reason: 'insufficient_history',
+            current: {
+                start: firstDate && firstDate > currentStart ? firstDate : currentStart,
+                end: latestDate,
+            },
+            previous: null,
+        };
+    }
+
     return {
         comparison_available: true,
         reason: null,

--- a/backend/growth_analysis.js
+++ b/backend/growth_analysis.js
@@ -1,0 +1,102 @@
+const RANGE_DAYS = new Map([
+    ['7d', 7],
+    ['30d', 30],
+    ['90d', 90],
+    ['180d', 180],
+    ['365d', 365],
+]);
+
+function normalizeDateString(value) {
+    if (!value) {
+        return null;
+    }
+
+    const dateString = String(value).slice(0, 10);
+    return /^\d{4}-\d{2}-\d{2}$/.test(dateString) ? dateString : null;
+}
+
+function addDays(dateString, days) {
+    const date = new Date(`${dateString}T00:00:00.000Z`);
+    date.setUTCDate(date.getUTCDate() + days);
+    return date.toISOString().slice(0, 10);
+}
+
+function getRangeDays(range) {
+    if (range === 'all') {
+        return null;
+    }
+
+    return RANGE_DAYS.get(range) || RANGE_DAYS.get('30d');
+}
+
+function buildComparisonPeriods(range, firstSnapshotDate, latestSnapshotDate) {
+    const firstDate = normalizeDateString(firstSnapshotDate);
+    const latestDate = normalizeDateString(latestSnapshotDate);
+
+    if (!latestDate) {
+        return {
+            comparison_available: false,
+            reason: 'no_data',
+            current: { start: null, end: null },
+            previous: null,
+        };
+    }
+
+    const days = getRangeDays(range);
+    if (days === null) {
+        return {
+            comparison_available: false,
+            reason: 'unbounded_range',
+            current: { start: firstDate || latestDate, end: latestDate },
+            previous: null,
+        };
+    }
+
+    const currentStart = addDays(latestDate, -(days - 1));
+    const previousEnd = addDays(currentStart, -1);
+    const previousStart = addDays(previousEnd, -(days - 1));
+
+    return {
+        comparison_available: true,
+        reason: null,
+        current: { start: currentStart, end: latestDate },
+        previous: { start: previousStart, end: previousEnd },
+    };
+}
+
+function formatGrowthMetrics(data = {}) {
+    return {
+        new_prs: Number.parseInt(data.new_prs, 10) || 0,
+        closed_merged_prs: Number.parseInt(data.closed_merged_prs, 10) || 0,
+        new_issues: Number.parseInt(data.new_issues, 10) || 0,
+        closed_issues: Number.parseInt(data.closed_issues, 10) || 0,
+        new_commits: Number.parseInt(data.new_commits, 10) || 0,
+        lines_added: Number.parseInt(data.lines_added, 10) || 0,
+        lines_deleted: Number.parseInt(data.lines_deleted, 10) || 0,
+    };
+}
+
+function calculateGrowth(current, previous) {
+    if (previous === 0) {
+        return current > 0 ? 100 : 0;
+    }
+
+    return Number((((current - previous) / previous) * 100).toFixed(2));
+}
+
+function calculateGrowthMetrics(current, previous) {
+    return {
+        prs: calculateGrowth(current.new_prs, previous.new_prs),
+        issues: calculateGrowth(current.new_issues, previous.new_issues),
+        commits: calculateGrowth(current.new_commits, previous.new_commits),
+        lines_added: calculateGrowth(current.lines_added, previous.lines_added),
+        lines_deleted: calculateGrowth(current.lines_deleted, previous.lines_deleted),
+    };
+}
+
+module.exports = {
+    buildComparisonPeriods,
+    calculateGrowthMetrics,
+    formatGrowthMetrics,
+    getRangeDays,
+};

--- a/backend/growth_analysis.js
+++ b/backend/growth_analysis.js
@@ -29,11 +29,14 @@ function getRangeDays(range) {
     return RANGE_DAYS.get(range) || RANGE_DAYS.get('30d');
 }
 
-function buildComparisonPeriods(range, firstSnapshotDate, latestSnapshotDate) {
+function buildComparisonPeriods(range, firstSnapshotDate, latestSnapshotDate, snapshotDates) {
     const firstDate = normalizeDateString(firstSnapshotDate);
     const latestDate = normalizeDateString(latestSnapshotDate);
+    const availableDates = Array.isArray(snapshotDates)
+        ? new Set(snapshotDates.map(normalizeDateString).filter(Boolean))
+        : null;
 
-    if (!latestDate) {
+    if (!latestDate || (availableDates && availableDates.size === 0)) {
         return {
             comparison_available: false,
             reason: 'no_data',
@@ -66,6 +69,19 @@ function buildComparisonPeriods(range, firstSnapshotDate, latestSnapshotDate) {
             },
             previous: null,
         };
+    }
+
+    if (availableDates) {
+        for (let date = previousStart; date <= latestDate; date = addDays(date, 1)) {
+            if (!availableDates.has(date)) {
+                return {
+                    comparison_available: false,
+                    reason: 'insufficient_history',
+                    current: { start: currentStart, end: latestDate },
+                    previous: null,
+                };
+            }
+        }
     }
 
     return {

--- a/backend/server.js
+++ b/backend/server.js
@@ -43,6 +43,11 @@ const {
     recordSuccessfulIngestion,
     withDataFreshness,
 } = require('./data_freshness');
+const {
+    buildComparisonPeriods,
+    calculateGrowthMetrics,
+    formatGrowthMetrics,
+} = require('./growth_analysis');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -2117,7 +2122,6 @@ app.get('/api/v1/sigs/compare', async (req, res) => {
 // GET /api/v1/organization/growth-analysis - Growth analysis for organization
 app.get('/api/v1/organization/growth-analysis', async (req, res) => {
     const range = req.query.range || '30d';
-    const cacheKey = `org:${ORG_NAME}:growth:${range}`;
     const cacheTTL = 60 * 10;
 
     try {
@@ -2126,7 +2130,21 @@ app.get('/api/v1/organization/growth-analysis', async (req, res) => {
             return res.status(404).json({ error: 'Monitored organization not found.' });
         }
 
-        // Check cache
+        const boundsResult = await pool.query(
+            `SELECT MIN(snapshot_date) AS first_snapshot_date,
+                    MAX(snapshot_date) AS latest_snapshot_date
+             FROM activity_snapshots
+             WHERE org_id = $1`,
+            [org.id]
+        );
+        const bounds = boundsResult.rows[0];
+        const periods = buildComparisonPeriods(
+            range,
+            bounds.first_snapshot_date ? formatDate(bounds.first_snapshot_date) : null,
+            bounds.latest_snapshot_date ? formatDate(bounds.latest_snapshot_date) : null,
+        );
+        const cacheKey = `org:${ORG_NAME}:growth:v2:${range}:window:${periods.current.start || 'missing'}:${periods.current.end || 'missing'}`;
+
         const cachedData = await redisClient.get(cacheKey);
         if (cachedData) {
             console.log(`Cache hit for ${cacheKey}`);
@@ -2134,21 +2152,6 @@ app.get('/api/v1/organization/growth-analysis', async (req, res) => {
         }
         console.log(`Cache miss for ${cacheKey}. Querying DB...`);
 
-        const { startDateStr, days } = parseRange(range);
-
-        // Calculate current period
-        const currentEndDate = new Date();
-        currentEndDate.setHours(0, 0, 0, 0);
-        const currentStartDate = new Date(currentEndDate);
-        currentStartDate.setDate(currentEndDate.getDate() - days);
-
-        // Calculate previous period
-        const previousEndDate = new Date(currentStartDate);
-        previousEndDate.setDate(previousEndDate.getDate() - 1);
-        const previousStartDate = new Date(previousEndDate);
-        previousStartDate.setDate(previousEndDate.getDate() - days);
-
-        // Query current period
         const currentResult = await pool.query(
             `SELECT 
                 COALESCE(SUM(new_prs), 0) as new_prs,
@@ -2160,66 +2163,45 @@ app.get('/api/v1/organization/growth-analysis', async (req, res) => {
                 COALESCE(SUM(lines_deleted), 0) as lines_deleted
              FROM activity_snapshots
              WHERE org_id = $1 AND snapshot_date >= $2 AND snapshot_date <= $3`,
-            [org.id, formatDate(currentStartDate), formatDate(currentEndDate)]
+            [org.id, periods.current.start, periods.current.end]
         );
 
-        // Query previous period
-        const previousResult = await pool.query(
-            `SELECT 
-                COALESCE(SUM(new_prs), 0) as new_prs,
-                COALESCE(SUM(closed_merged_prs), 0) as closed_merged_prs,
-                COALESCE(SUM(new_issues), 0) as new_issues,
-                COALESCE(SUM(closed_issues), 0) as closed_issues,
-                COALESCE(SUM(new_commits), 0) as new_commits,
-                COALESCE(SUM(lines_added), 0) as lines_added,
-                COALESCE(SUM(lines_deleted), 0) as lines_deleted
-             FROM activity_snapshots
-             WHERE org_id = $1 AND snapshot_date >= $2 AND snapshot_date <= $3`,
-            [org.id, formatDate(previousStartDate), formatDate(previousEndDate)]
-        );
+        const current = formatGrowthMetrics(currentResult.rows[0]);
+        let previous = null;
+        let growth = null;
 
-        const current = currentResult.rows[0];
-        const previous = previousResult.rows[0];
-
-        // Calculate growth rates
-        const calculateGrowth = (curr, prev) => {
-            if (prev === 0) return curr > 0 ? 100 : 0;
-            return ((curr - prev) / prev * 100).toFixed(2);
-        };
-
-        const growth = {
-            prs: parseFloat(calculateGrowth(parseInt(current.new_prs), parseInt(previous.new_prs))),
-            issues: parseFloat(calculateGrowth(parseInt(current.new_issues), parseInt(previous.new_issues))),
-            commits: parseFloat(calculateGrowth(parseInt(current.new_commits), parseInt(previous.new_commits))),
-            lines_added: parseFloat(calculateGrowth(parseInt(current.lines_added), parseInt(previous.lines_added))),
-            lines_deleted: parseFloat(calculateGrowth(parseInt(current.lines_deleted), parseInt(previous.lines_deleted)))
-        };
-
-        // Convert bigint to number for JSON
-        const formatMetrics = (data) => ({
-            new_prs: parseInt(data.new_prs),
-            closed_merged_prs: parseInt(data.closed_merged_prs),
-            new_issues: parseInt(data.new_issues),
-            closed_issues: parseInt(data.closed_issues),
-            new_commits: parseInt(data.new_commits),
-            lines_added: parseInt(data.lines_added),
-            lines_deleted: parseInt(data.lines_deleted)
-        });
+        if (periods.comparison_available) {
+            const previousResult = await pool.query(
+                `SELECT
+                    COALESCE(SUM(new_prs), 0) as new_prs,
+                    COALESCE(SUM(closed_merged_prs), 0) as closed_merged_prs,
+                    COALESCE(SUM(new_issues), 0) as new_issues,
+                    COALESCE(SUM(closed_issues), 0) as closed_issues,
+                    COALESCE(SUM(new_commits), 0) as new_commits,
+                    COALESCE(SUM(lines_added), 0) as lines_added,
+                    COALESCE(SUM(lines_deleted), 0) as lines_deleted
+                 FROM activity_snapshots
+                 WHERE org_id = $1 AND snapshot_date >= $2 AND snapshot_date <= $3`,
+                [org.id, periods.previous.start, periods.previous.end]
+            );
+            previous = formatGrowthMetrics(previousResult.rows[0]);
+            growth = calculateGrowthMetrics(current, previous);
+        }
 
         const responseData = {
+            comparison_available: periods.comparison_available,
+            comparison_unavailable_reason: periods.reason,
             period: {
                 current: {
-                    start: formatDate(currentStartDate),
-                    end: formatDate(currentEndDate),
-                    metrics: formatMetrics(current)
+                    ...periods.current,
+                    metrics: current,
                 },
-                previous: {
-                    start: formatDate(previousStartDate),
-                    end: formatDate(previousEndDate),
-                    metrics: formatMetrics(previous)
-                }
+                previous: periods.previous ? {
+                    ...periods.previous,
+                    metrics: previous,
+                } : null,
             },
-            growth: growth
+            growth,
         };
 
         await redisClient.setEx(cacheKey, cacheTTL, JSON.stringify(responseData));
@@ -2235,16 +2217,29 @@ app.get('/api/v1/organization/growth-analysis', async (req, res) => {
 app.get('/api/v1/sig/:sigId/growth-analysis', async (req, res) => {
     const { sigId } = req.params;
     const range = req.query.range || '30d';
-    const cacheKey = `sig:${sigId}:growth:${range}`;
     const cacheTTL = 60 * 10;
 
     try {
-        const sigResult = await pool.query('SELECT id, name FROM special_interest_groups WHERE id = $1', [sigId]);
+        const sigResult = await pool.query('SELECT id, name, org_id FROM special_interest_groups WHERE id = $1', [sigId]);
         if (sigResult.rows.length === 0) {
             return res.status(404).json({ error: 'Monitored SIG not found.' });
         }
 
-        // Check cache
+        const boundsResult = await pool.query(
+            `SELECT MIN(snapshot_date) AS first_snapshot_date,
+                    MAX(snapshot_date) AS latest_snapshot_date
+             FROM activity_snapshots
+             WHERE org_id = $1`,
+            [sigResult.rows[0].org_id]
+        );
+        const bounds = boundsResult.rows[0];
+        const periods = buildComparisonPeriods(
+            range,
+            bounds.first_snapshot_date ? formatDate(bounds.first_snapshot_date) : null,
+            bounds.latest_snapshot_date ? formatDate(bounds.latest_snapshot_date) : null,
+        );
+        const cacheKey = `sig:${sigId}:growth:v2:${range}:window:${periods.current.start || 'missing'}:${periods.current.end || 'missing'}`;
+
         const cachedData = await redisClient.get(cacheKey);
         if (cachedData) {
             console.log(`Cache hit for ${cacheKey}`);
@@ -2252,20 +2247,6 @@ app.get('/api/v1/sig/:sigId/growth-analysis', async (req, res) => {
         }
         console.log(`Cache miss for ${cacheKey}. Querying DB...`);
 
-        const { startDateStr, days } = parseRange(range);
-
-        // Calculate periods
-        const currentEndDate = new Date();
-        currentEndDate.setHours(0, 0, 0, 0);
-        const currentStartDate = new Date(currentEndDate);
-        currentStartDate.setDate(currentEndDate.getDate() - days);
-
-        const previousEndDate = new Date(currentStartDate);
-        previousEndDate.setDate(previousEndDate.getDate() - 1);
-        const previousStartDate = new Date(previousEndDate);
-        previousStartDate.setDate(previousEndDate.getDate() - days);
-
-        // Query current period
         const currentResult = await pool.query(
             `SELECT 
                 COALESCE(SUM(new_prs), 0) as new_prs,
@@ -2277,66 +2258,49 @@ app.get('/api/v1/sig/:sigId/growth-analysis', async (req, res) => {
                 COALESCE(SUM(lines_deleted), 0) as lines_deleted
              FROM sig_snapshots
              WHERE sig_id = $1 AND snapshot_date >= $2 AND snapshot_date <= $3`,
-            [sigId, formatDate(currentStartDate), formatDate(currentEndDate)]
+            [sigId, periods.current.start, periods.current.end]
         );
 
-        // Query previous period
-        const previousResult = await pool.query(
-            `SELECT 
-                COALESCE(SUM(new_prs), 0) as new_prs,
-                COALESCE(SUM(closed_merged_prs), 0) as closed_merged_prs,
-                COALESCE(SUM(new_issues), 0) as new_issues,
-                COALESCE(SUM(closed_issues), 0) as closed_issues,
-                COALESCE(SUM(new_commits), 0) as new_commits,
-                COALESCE(SUM(lines_added), 0) as lines_added,
-                COALESCE(SUM(lines_deleted), 0) as lines_deleted
-             FROM sig_snapshots
-             WHERE sig_id = $1 AND snapshot_date >= $2 AND snapshot_date <= $3`,
-            [sigId, formatDate(previousStartDate), formatDate(previousEndDate)]
-        );
+        const current = formatGrowthMetrics(currentResult.rows[0]);
+        let previous = null;
+        let growth = null;
 
-        const current = currentResult.rows[0];
-        const previous = previousResult.rows[0];
-
-        // Calculate growth rates
-        const calculateGrowth = (curr, prev) => {
-            if (prev === 0) return curr > 0 ? 100 : 0;
-            return ((curr - prev) / prev * 100).toFixed(2);
-        };
-
-        const growth = {
-            prs: parseFloat(calculateGrowth(parseInt(current.new_prs), parseInt(previous.new_prs))),
-            issues: parseFloat(calculateGrowth(parseInt(current.new_issues), parseInt(previous.new_issues))),
-            commits: parseFloat(calculateGrowth(parseInt(current.new_commits), parseInt(previous.new_commits))),
-            lines_added: parseFloat(calculateGrowth(parseInt(current.lines_added), parseInt(previous.lines_added))),
-            lines_deleted: parseFloat(calculateGrowth(parseInt(current.lines_deleted), parseInt(previous.lines_deleted)))
-        };
-
-        const formatMetrics = (data) => ({
-            new_prs: parseInt(data.new_prs),
-            closed_merged_prs: parseInt(data.closed_merged_prs),
-            new_issues: parseInt(data.new_issues),
-            closed_issues: parseInt(data.closed_issues),
-            new_commits: parseInt(data.new_commits),
-            lines_added: parseInt(data.lines_added),
-            lines_deleted: parseInt(data.lines_deleted)
-        });
+        if (periods.comparison_available) {
+            const previousResult = await pool.query(
+                `SELECT
+                    COALESCE(SUM(new_prs), 0) as new_prs,
+                    COALESCE(SUM(closed_merged_prs), 0) as closed_merged_prs,
+                    COALESCE(SUM(new_issues), 0) as new_issues,
+                    COALESCE(SUM(closed_issues), 0) as closed_issues,
+                    COALESCE(SUM(new_commits), 0) as new_commits,
+                    COALESCE(SUM(lines_added), 0) as lines_added,
+                    COALESCE(SUM(lines_deleted), 0) as lines_deleted
+                 FROM sig_snapshots
+                 WHERE sig_id = $1 AND snapshot_date >= $2 AND snapshot_date <= $3`,
+                [sigId, periods.previous.start, periods.previous.end]
+            );
+            previous = formatGrowthMetrics(previousResult.rows[0]);
+            growth = calculateGrowthMetrics(current, previous);
+        }
 
         const responseData = {
-            sig: sigResult.rows[0],
+            sig: {
+                id: sigResult.rows[0].id,
+                name: sigResult.rows[0].name,
+            },
+            comparison_available: periods.comparison_available,
+            comparison_unavailable_reason: periods.reason,
             period: {
                 current: {
-                    start: formatDate(currentStartDate),
-                    end: formatDate(currentEndDate),
-                    metrics: formatMetrics(current)
+                    ...periods.current,
+                    metrics: current,
                 },
-                previous: {
-                    start: formatDate(previousStartDate),
-                    end: formatDate(previousEndDate),
-                    metrics: formatMetrics(previous)
-                }
+                previous: periods.previous ? {
+                    ...periods.previous,
+                    metrics: previous,
+                } : null,
             },
-            growth: growth
+            growth,
         };
 
         await redisClient.setEx(cacheKey, cacheTTL, JSON.stringify(responseData));
@@ -2774,8 +2738,12 @@ app.post('/api/v1/export/pdf', async (req, res) => {
             }
             doc.moveDown(0.5);
 
-            doc.text(`上一周期: ${growthData.period.previous.start} 至 ${growthData.period.previous.end}`);
-            if (growthData.period.previous.metrics) {
+            if (growthData.period.previous) {
+                doc.text(`上一周期: ${growthData.period.previous.start} 至 ${growthData.period.previous.end}`);
+            } else {
+                doc.text('全部时间范围不提供环比');
+            }
+            if (growthData.period.previous?.metrics) {
                 const prev = growthData.period.previous.metrics;
                 doc.text(`  PRs: ${prev.new_prs}, Issues: ${prev.new_issues}, Commits: ${prev.new_commits}`);
             }

--- a/backend/server.js
+++ b/backend/server.js
@@ -2158,21 +2158,23 @@ app.get('/api/v1/organization/growth-analysis', async (req, res) => {
         }
         console.log(`Cache miss for ${cacheKey}. Querying DB...`);
 
-        const currentResult = await pool.query(
-            `SELECT 
-                COALESCE(SUM(new_prs), 0) as new_prs,
-                COALESCE(SUM(closed_merged_prs), 0) as closed_merged_prs,
-                COALESCE(SUM(new_issues), 0) as new_issues,
-                COALESCE(SUM(closed_issues), 0) as closed_issues,
-                COALESCE(SUM(new_commits), 0) as new_commits,
-                COALESCE(SUM(lines_added), 0) as lines_added,
-                COALESCE(SUM(lines_deleted), 0) as lines_deleted
-             FROM activity_snapshots
-             WHERE org_id = $1 AND snapshot_date >= $2 AND snapshot_date <= $3`,
-            [org.id, periods.current.start, periods.current.end]
-        );
-
-        const current = formatGrowthMetrics(currentResult.rows[0]);
+        let current = null;
+        if (hasCompletePeriodDates(periods.current)) {
+            const currentResult = await pool.query(
+                `SELECT
+                    COALESCE(SUM(new_prs), 0) as new_prs,
+                    COALESCE(SUM(closed_merged_prs), 0) as closed_merged_prs,
+                    COALESCE(SUM(new_issues), 0) as new_issues,
+                    COALESCE(SUM(closed_issues), 0) as closed_issues,
+                    COALESCE(SUM(new_commits), 0) as new_commits,
+                    COALESCE(SUM(lines_added), 0) as lines_added,
+                    COALESCE(SUM(lines_deleted), 0) as lines_deleted
+                 FROM activity_snapshots
+                 WHERE org_id = $1 AND snapshot_date >= $2 AND snapshot_date <= $3`,
+                [org.id, periods.current.start, periods.current.end]
+            );
+            current = formatGrowthMetrics(currentResult.rows[0]);
+        }
         let previous = null;
         let growth = null;
 
@@ -2259,21 +2261,23 @@ app.get('/api/v1/sig/:sigId/growth-analysis', async (req, res) => {
         }
         console.log(`Cache miss for ${cacheKey}. Querying DB...`);
 
-        const currentResult = await pool.query(
-            `SELECT 
-                COALESCE(SUM(new_prs), 0) as new_prs,
-                COALESCE(SUM(closed_merged_prs), 0) as closed_merged_prs,
-                COALESCE(SUM(new_issues), 0) as new_issues,
-                COALESCE(SUM(closed_issues), 0) as closed_issues,
-                COALESCE(SUM(new_commits), 0) as new_commits,
-                COALESCE(SUM(lines_added), 0) as lines_added,
-                COALESCE(SUM(lines_deleted), 0) as lines_deleted
-             FROM sig_snapshots
-             WHERE sig_id = $1 AND snapshot_date >= $2 AND snapshot_date <= $3`,
-            [sigId, periods.current.start, periods.current.end]
-        );
-
-        const current = formatGrowthMetrics(currentResult.rows[0]);
+        let current = null;
+        if (hasCompletePeriodDates(periods.current)) {
+            const currentResult = await pool.query(
+                `SELECT
+                    COALESCE(SUM(new_prs), 0) as new_prs,
+                    COALESCE(SUM(closed_merged_prs), 0) as closed_merged_prs,
+                    COALESCE(SUM(new_issues), 0) as new_issues,
+                    COALESCE(SUM(closed_issues), 0) as closed_issues,
+                    COALESCE(SUM(new_commits), 0) as new_commits,
+                    COALESCE(SUM(lines_added), 0) as lines_added,
+                    COALESCE(SUM(lines_deleted), 0) as lines_deleted
+                 FROM sig_snapshots
+                 WHERE sig_id = $1 AND snapshot_date >= $2 AND snapshot_date <= $3`,
+                [sigId, periods.current.start, periods.current.end]
+            );
+            current = formatGrowthMetrics(currentResult.rows[0]);
+        }
         let previous = null;
         let growth = null;
 
@@ -2744,7 +2748,9 @@ app.post('/api/v1/export/pdf', async (req, res) => {
             doc.fontSize(11);
 
             if (!hasCompletePeriodDates(growthData.period.current)) {
-                doc.text('暂无数据，无法进行周期对比');
+                doc.text(growthData.comparison_unavailable_reason === 'incomplete_current_period'
+                    ? '当前周期数据不完整，暂不展示指标或环比'
+                    : '暂无数据，无法进行周期对比');
             } else {
                 doc.text(`当前周期: ${growthData.period.current.start} 至 ${growthData.period.current.end}`);
                 if (growthData.period.current.metrics) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -2133,7 +2133,11 @@ app.get('/api/v1/organization/growth-analysis', async (req, res) => {
 
         const boundsResult = await pool.query(
             `SELECT MIN(snapshot_date) AS first_snapshot_date,
-                    MAX(snapshot_date) AS latest_snapshot_date
+                    MAX(snapshot_date) AS latest_snapshot_date,
+                    COALESCE(
+                        ARRAY_AGG(snapshot_date::TEXT ORDER BY snapshot_date),
+                        ARRAY[]::TEXT[]
+                    ) AS snapshot_dates
              FROM activity_snapshots
              WHERE org_id = $1`,
             [org.id]
@@ -2143,8 +2147,9 @@ app.get('/api/v1/organization/growth-analysis', async (req, res) => {
             range,
             bounds.first_snapshot_date ? formatDate(bounds.first_snapshot_date) : null,
             bounds.latest_snapshot_date ? formatDate(bounds.latest_snapshot_date) : null,
+            bounds.snapshot_dates,
         );
-        const cacheKey = `org:${ORG_NAME}:growth:v2:${range}:window:${periods.current.start || 'missing'}:${periods.current.end || 'missing'}`;
+        const cacheKey = `org:${ORG_NAME}:growth:v3:${range}:window:${periods.current.start || 'missing'}:${periods.current.end || 'missing'}:coverage:${bounds.snapshot_dates.length}`;
 
         const cachedData = await redisClient.get(cacheKey);
         if (cachedData) {
@@ -2227,19 +2232,25 @@ app.get('/api/v1/sig/:sigId/growth-analysis', async (req, res) => {
         }
 
         const boundsResult = await pool.query(
-            `SELECT MIN(snapshot_date) AS first_snapshot_date,
-                    MAX(snapshot_date) AS latest_snapshot_date
+            `SELECT
+                (SELECT MIN(snapshot_date) FROM sig_snapshots WHERE sig_id = $2) AS first_snapshot_date,
+                MAX(snapshot_date) AS latest_snapshot_date,
+                (SELECT COALESCE(
+                    ARRAY_AGG(snapshot_date::TEXT ORDER BY snapshot_date),
+                    ARRAY[]::TEXT[]
+                 ) FROM sig_snapshots WHERE sig_id = $2) AS snapshot_dates
              FROM activity_snapshots
              WHERE org_id = $1`,
-            [sigResult.rows[0].org_id]
+            [sigResult.rows[0].org_id, sigId]
         );
         const bounds = boundsResult.rows[0];
         const periods = buildComparisonPeriods(
             range,
             bounds.first_snapshot_date ? formatDate(bounds.first_snapshot_date) : null,
             bounds.latest_snapshot_date ? formatDate(bounds.latest_snapshot_date) : null,
+            bounds.snapshot_dates,
         );
-        const cacheKey = `sig:${sigId}:growth:v2:${range}:window:${periods.current.start || 'missing'}:${periods.current.end || 'missing'}`;
+        const cacheKey = `sig:${sigId}:growth:v3:${range}:window:${periods.current.start || 'missing'}:${periods.current.end || 'missing'}:coverage:${bounds.snapshot_dates.length}`;
 
         const cachedData = await redisClient.get(cacheKey);
         if (cachedData) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -2740,8 +2740,12 @@ app.post('/api/v1/export/pdf', async (req, res) => {
 
             if (growthData.period.previous) {
                 doc.text(`上一周期: ${growthData.period.previous.start} 至 ${growthData.period.previous.end}`);
-            } else {
+            } else if (growthData.comparison_unavailable_reason === 'unbounded_range') {
                 doc.text('全部时间范围不提供环比');
+            } else if (growthData.comparison_unavailable_reason === 'insufficient_history') {
+                doc.text('历史数据不足，暂不提供周期环比');
+            } else {
+                doc.text('暂无数据，无法进行周期对比');
             }
             if (growthData.period.previous?.metrics) {
                 const prev = growthData.period.previous.metrics;

--- a/backend/server.js
+++ b/backend/server.js
@@ -47,6 +47,7 @@ const {
     buildComparisonPeriods,
     calculateGrowthMetrics,
     formatGrowthMetrics,
+    hasCompletePeriodDates,
 } = require('./growth_analysis');
 
 const app = express();
@@ -2731,25 +2732,29 @@ app.post('/api/v1/export/pdf', async (req, res) => {
             doc.moveDown();
             doc.fontSize(11);
 
-            doc.text(`当前周期: ${growthData.period.current.start} 至 ${growthData.period.current.end}`);
-            if (growthData.period.current.metrics) {
-                const curr = growthData.period.current.metrics;
-                doc.text(`  PRs: ${curr.new_prs}, Issues: ${curr.new_issues}, Commits: ${curr.new_commits}`);
-            }
-            doc.moveDown(0.5);
-
-            if (growthData.period.previous) {
-                doc.text(`上一周期: ${growthData.period.previous.start} 至 ${growthData.period.previous.end}`);
-            } else if (growthData.comparison_unavailable_reason === 'unbounded_range') {
-                doc.text('全部时间范围不提供环比');
-            } else if (growthData.comparison_unavailable_reason === 'insufficient_history') {
-                doc.text('历史数据不足，暂不提供周期环比');
-            } else {
+            if (!hasCompletePeriodDates(growthData.period.current)) {
                 doc.text('暂无数据，无法进行周期对比');
-            }
-            if (growthData.period.previous?.metrics) {
-                const prev = growthData.period.previous.metrics;
-                doc.text(`  PRs: ${prev.new_prs}, Issues: ${prev.new_issues}, Commits: ${prev.new_commits}`);
+            } else {
+                doc.text(`当前周期: ${growthData.period.current.start} 至 ${growthData.period.current.end}`);
+                if (growthData.period.current.metrics) {
+                    const curr = growthData.period.current.metrics;
+                    doc.text(`  PRs: ${curr.new_prs}, Issues: ${curr.new_issues}, Commits: ${curr.new_commits}`);
+                }
+                doc.moveDown(0.5);
+
+                if (growthData.period.previous) {
+                    doc.text(`上一周期: ${growthData.period.previous.start} 至 ${growthData.period.previous.end}`);
+                } else if (growthData.comparison_unavailable_reason === 'unbounded_range') {
+                    doc.text('全部时间范围不提供环比');
+                } else if (growthData.comparison_unavailable_reason === 'insufficient_history') {
+                    doc.text('历史数据不足，暂不提供周期环比');
+                } else {
+                    doc.text('暂无数据，无法进行周期对比');
+                }
+                if (growthData.period.previous?.metrics) {
+                    const prev = growthData.period.previous.metrics;
+                    doc.text(`  PRs: ${prev.new_prs}, Issues: ${prev.new_issues}, Commits: ${prev.new_commits}`);
+                }
             }
             doc.moveDown(1.5);
         }

--- a/backend/test/growth_analysis.test.js
+++ b/backend/test/growth_analysis.test.js
@@ -6,6 +6,7 @@ const {
     calculateGrowthMetrics,
     formatGrowthMetrics,
     getRangeDays,
+    hasCompletePeriodDates,
 } = require('../growth_analysis');
 
 test('builds adjacent, equal seven-day comparison windows from the latest snapshot', () => {
@@ -40,14 +41,24 @@ test('uses the complete data bounds and disables comparison for all time', () =>
 });
 
 test('returns a no-data window when no snapshots exist', () => {
+    const periods = buildComparisonPeriods('30d', null, null);
+
     assert.deepEqual(
-        buildComparisonPeriods('30d', null, null),
+        periods,
         {
             comparison_available: false,
             reason: 'no_data',
             current: { start: null, end: null },
             previous: null,
         },
+    );
+    assert.equal(hasCompletePeriodDates(periods.current), false);
+});
+
+test('recognizes periods with both export dates', () => {
+    assert.equal(
+        hasCompletePeriodDates({ start: '2026-08-10', end: '2026-09-08' }),
+        true,
     );
 });
 

--- a/backend/test/growth_analysis.test.js
+++ b/backend/test/growth_analysis.test.js
@@ -157,6 +157,25 @@ test('returns no data when an anchored SIG has no snapshots', () => {
     );
 });
 
+test('rejects a SIG snapshot newer than the organization anchor', () => {
+    assert.deepEqual(
+        buildComparisonPeriods('30d', '2026-09-09', '2026-09-08', ['2026-09-09']),
+        {
+            comparison_available: false,
+            reason: 'incomplete_current_period',
+            current: { start: null, end: null },
+            previous: null,
+        },
+    );
+});
+
+test('rejects reversed export period dates', () => {
+    assert.equal(
+        hasCompletePeriodDates({ start: '2026-09-09', end: '2026-09-08' }),
+        false,
+    );
+});
+
 test('supports leap-day date arithmetic and defaults unknown ranges to thirty days', () => {
     assert.equal(getRangeDays('unknown'), 30);
     assert.deepEqual(

--- a/backend/test/growth_analysis.test.js
+++ b/backend/test/growth_analysis.test.js
@@ -51,6 +51,32 @@ test('returns a no-data window when no snapshots exist', () => {
     );
 });
 
+test('disables comparison when the previous window is not fully retained', () => {
+    assert.deepEqual(
+        buildComparisonPeriods('30d', '2026-08-10', '2026-09-08'),
+        {
+            comparison_available: false,
+            reason: 'insufficient_history',
+            current: { start: '2026-08-10', end: '2026-09-08' },
+            previous: null,
+        },
+    );
+});
+
+test('shows only the actually retained portion of an incomplete current window', () => {
+    assert.deepEqual(
+        buildComparisonPeriods('30d', '2026-08-20', '2026-09-08').current,
+        { start: '2026-08-20', end: '2026-09-08' },
+    );
+});
+
+test('allows comparison when history begins on the previous window boundary', () => {
+    assert.equal(
+        buildComparisonPeriods('30d', '2026-07-11', '2026-09-08').comparison_available,
+        true,
+    );
+});
+
 test('supports leap-day date arithmetic and defaults unknown ranges to thirty days', () => {
     assert.equal(getRangeDays('unknown'), 30);
     assert.deepEqual(

--- a/backend/test/growth_analysis.test.js
+++ b/backend/test/growth_analysis.test.js
@@ -42,12 +42,29 @@ test('builds adjacent, equal thirty-day comparison windows across month boundari
 });
 
 test('uses the complete data bounds and disables comparison for all time', () => {
+    const snapshotDates = buildDateRange('2024-09-05', '2026-09-08');
+
     assert.deepEqual(
-        buildComparisonPeriods('all', '2024-09-05', '2026-09-08'),
+        buildComparisonPeriods('all', '2024-09-05', '2026-09-08', snapshotDates),
         {
             comparison_available: false,
             reason: 'unbounded_range',
             current: { start: '2024-09-05', end: '2026-09-08' },
+            previous: null,
+        },
+    );
+});
+
+test('omits all-time totals when retained history contains a gap', () => {
+    const snapshotDates = buildDateRange('2026-09-01', '2026-09-08')
+        .filter(date => date !== '2026-09-04');
+
+    assert.deepEqual(
+        buildComparisonPeriods('all', '2026-09-01', '2026-09-08', snapshotDates),
+        {
+            comparison_available: false,
+            reason: 'incomplete_current_period',
+            current: { start: null, end: null },
             previous: null,
         },
     );

--- a/backend/test/growth_analysis.test.js
+++ b/backend/test/growth_analysis.test.js
@@ -1,0 +1,73 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    buildComparisonPeriods,
+    calculateGrowthMetrics,
+    formatGrowthMetrics,
+    getRangeDays,
+} = require('../growth_analysis');
+
+test('builds adjacent, equal seven-day comparison windows from the latest snapshot', () => {
+    assert.deepEqual(
+        buildComparisonPeriods('7d', '2024-09-05', '2026-09-08'),
+        {
+            comparison_available: true,
+            reason: null,
+            current: { start: '2026-09-02', end: '2026-09-08' },
+            previous: { start: '2026-08-26', end: '2026-09-01' },
+        },
+    );
+});
+
+test('builds adjacent, equal thirty-day comparison windows across month boundaries', () => {
+    const periods = buildComparisonPeriods('30d', '2024-09-05', '2026-09-08');
+
+    assert.deepEqual(periods.current, { start: '2026-08-10', end: '2026-09-08' });
+    assert.deepEqual(periods.previous, { start: '2026-07-11', end: '2026-08-09' });
+});
+
+test('uses the complete data bounds and disables comparison for all time', () => {
+    assert.deepEqual(
+        buildComparisonPeriods('all', '2024-09-05', '2026-09-08'),
+        {
+            comparison_available: false,
+            reason: 'unbounded_range',
+            current: { start: '2024-09-05', end: '2026-09-08' },
+            previous: null,
+        },
+    );
+});
+
+test('returns a no-data window when no snapshots exist', () => {
+    assert.deepEqual(
+        buildComparisonPeriods('30d', null, null),
+        {
+            comparison_available: false,
+            reason: 'no_data',
+            current: { start: null, end: null },
+            previous: null,
+        },
+    );
+});
+
+test('supports leap-day date arithmetic and defaults unknown ranges to thirty days', () => {
+    assert.equal(getRangeDays('unknown'), 30);
+    assert.deepEqual(
+        buildComparisonPeriods('7d', '2024-01-01', '2024-03-01').current,
+        { start: '2024-02-24', end: '2024-03-01' },
+    );
+});
+
+test('normalizes database metrics and calculates growth', () => {
+    const current = formatGrowthMetrics({ new_prs: '20', new_issues: '5', new_commits: '0' });
+    const previous = formatGrowthMetrics({ new_prs: '10', new_issues: '0', new_commits: '0' });
+
+    assert.deepEqual(calculateGrowthMetrics(current, previous), {
+        prs: 100,
+        issues: 100,
+        commits: 0,
+        lines_added: 0,
+        lines_deleted: 0,
+    });
+});

--- a/backend/test/growth_analysis.test.js
+++ b/backend/test/growth_analysis.test.js
@@ -9,6 +9,19 @@ const {
     hasCompletePeriodDates,
 } = require('../growth_analysis');
 
+function buildDateRange(start, end) {
+    const dates = [];
+    const current = new Date(`${start}T00:00:00.000Z`);
+    const last = new Date(`${end}T00:00:00.000Z`);
+
+    while (current <= last) {
+        dates.push(current.toISOString().slice(0, 10));
+        current.setUTCDate(current.getUTCDate() + 1);
+    }
+
+    return dates;
+}
+
 test('builds adjacent, equal seven-day comparison windows from the latest snapshot', () => {
     assert.deepEqual(
         buildComparisonPeriods('7d', '2024-09-05', '2026-09-08'),
@@ -82,9 +95,33 @@ test('shows only the actually retained portion of an incomplete current window',
 });
 
 test('allows comparison when history begins on the previous window boundary', () => {
+    const snapshotDates = buildDateRange('2026-07-11', '2026-09-08');
+
     assert.equal(
-        buildComparisonPeriods('30d', '2026-07-11', '2026-09-08').comparison_available,
+        buildComparisonPeriods('30d', '2026-07-11', '2026-09-08', snapshotDates).comparison_available,
         true,
+    );
+});
+
+test('disables comparison when either window contains an internal gap', () => {
+    const snapshotDates = buildDateRange('2026-07-11', '2026-09-08')
+        .filter(date => date !== '2026-08-15');
+
+    assert.deepEqual(
+        buildComparisonPeriods('30d', '2026-07-11', '2026-09-08', snapshotDates),
+        {
+            comparison_available: false,
+            reason: 'insufficient_history',
+            current: { start: '2026-08-10', end: '2026-09-08' },
+            previous: null,
+        },
+    );
+});
+
+test('returns no data when an anchored SIG has no snapshots', () => {
+    assert.equal(
+        buildComparisonPeriods('30d', null, '2026-09-08', []).reason,
+        'no_data',
     );
 });
 

--- a/backend/test/growth_analysis.test.js
+++ b/backend/test/growth_analysis.test.js
@@ -103,9 +103,24 @@ test('allows comparison when history begins on the previous window boundary', ()
     );
 });
 
-test('disables comparison when either window contains an internal gap', () => {
+test('omits current metrics when the current window contains an internal gap', () => {
     const snapshotDates = buildDateRange('2026-07-11', '2026-09-08')
         .filter(date => date !== '2026-08-15');
+
+    assert.deepEqual(
+        buildComparisonPeriods('30d', '2026-07-11', '2026-09-08', snapshotDates),
+        {
+            comparison_available: false,
+            reason: 'incomplete_current_period',
+            current: { start: null, end: null },
+            previous: null,
+        },
+    );
+});
+
+test('keeps a complete current window when only the previous window has a gap', () => {
+    const snapshotDates = buildDateRange('2026-07-11', '2026-09-08')
+        .filter(date => date !== '2026-08-01');
 
     assert.deepEqual(
         buildComparisonPeriods('30d', '2026-07-11', '2026-09-08', snapshotDates),

--- a/frontend/src/components/GrowthReport.jsx
+++ b/frontend/src/components/GrowthReport.jsx
@@ -98,7 +98,9 @@ const GrowthReport = ({ growthData, loading }) => {
                 <p className="mt-4 rounded-lg border border-gray-700 bg-gray-900/40 px-4 py-3 text-sm text-gray-400">
                     {growthData.comparison_unavailable_reason === 'unbounded_range'
                         ? '全部时间范围不提供环比，请选择具体时间范围。'
-                        : '暂无足够数据进行周期对比。'}
+                        : growthData.comparison_unavailable_reason === 'insufficient_history'
+                            ? '历史数据不足，暂不提供周期环比。'
+                            : '暂无足够数据进行周期对比。'}
                 </p>
             )}
         </div>

--- a/frontend/src/components/GrowthReport.jsx
+++ b/frontend/src/components/GrowthReport.jsx
@@ -109,6 +109,7 @@ const GrowthReport = ({ growthData, loading }) => {
 
 const PeriodCard = ({ title, period, highlight }) => {
     const { start, end, metrics } = period;
+    const hasCompleteDates = Boolean(start && end);
 
     return (
         <div className={`rounded-lg p-4 border ${
@@ -118,15 +119,17 @@ const PeriodCard = ({ title, period, highlight }) => {
         }`}>
             <h3 className="text-sm font-semibold mb-2 text-gray-300">{title}</h3>
             <p className="text-xs text-gray-400 mb-3">
-                {start && end ? `${start} 至 ${end}` : '暂无数据'}
+                {hasCompleteDates ? `${start} 至 ${end}` : '暂无数据'}
             </p>
-            <div className="space-y-1.5">
-                <MetricRow label="PR" value={metrics.new_prs} />
-                <MetricRow label="Issue" value={metrics.new_issues} />
-                <MetricRow label="Commit" value={metrics.new_commits} />
-                <MetricRow label="新增代码" value={metrics.lines_added} />
-                <MetricRow label="删除代码" value={metrics.lines_deleted} />
-            </div>
+            {hasCompleteDates && metrics && (
+                <div className="space-y-1.5">
+                    <MetricRow label="PR" value={metrics.new_prs} />
+                    <MetricRow label="Issue" value={metrics.new_issues} />
+                    <MetricRow label="Commit" value={metrics.new_commits} />
+                    <MetricRow label="新增代码" value={metrics.lines_added} />
+                    <MetricRow label="删除代码" value={metrics.lines_deleted} />
+                </div>
+            )}
         </div>
     );
 };

--- a/frontend/src/components/GrowthReport.jsx
+++ b/frontend/src/components/GrowthReport.jsx
@@ -98,6 +98,8 @@ const GrowthReport = ({ growthData, loading }) => {
                 <p className="mt-4 rounded-lg border border-gray-700 bg-gray-900/40 px-4 py-3 text-sm text-gray-400">
                     {growthData.comparison_unavailable_reason === 'unbounded_range'
                         ? '全部时间范围不提供环比，请选择具体时间范围。'
+                        : growthData.comparison_unavailable_reason === 'incomplete_current_period'
+                            ? '当前周期数据不完整，暂不展示指标或环比。'
                         : growthData.comparison_unavailable_reason === 'insufficient_history'
                             ? '历史数据不足，暂不提供周期环比。'
                             : '暂无足够数据进行周期对比。'}

--- a/frontend/src/components/GrowthReport.jsx
+++ b/frontend/src/components/GrowthReport.jsx
@@ -21,6 +21,9 @@ const GrowthReport = ({ growthData, loading }) => {
     }
 
     const { period, growth } = growthData;
+    const comparisonAvailable = growthData.comparison_available !== false
+        && Boolean(period.previous)
+        && Boolean(growth);
 
     const getGrowthColor = (value) => {
         if (value > 10) return 'text-green-400';
@@ -43,52 +46,61 @@ const GrowthReport = ({ growthData, loading }) => {
             <h2 className="text-xl font-bold mb-6 text-white">增长趋势分析</h2>
             
             {/* Period Comparison Cards */}
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+            <div className={`grid grid-cols-1 gap-4 ${comparisonAvailable ? 'md:grid-cols-2 mb-6' : ''}`}>
                 <PeriodCard 
                     title="当前周期" 
                     period={period.current}
                     highlight={true}
                 />
-                <PeriodCard 
-                    title="上一周期" 
-                    period={period.previous}
-                    highlight={false}
-                />
+                {comparisonAvailable && (
+                    <PeriodCard
+                        title="上一周期"
+                        period={period.previous}
+                        highlight={false}
+                    />
+                )}
             </div>
-            
-            {/* Growth Metrics */}
-            <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-                <GrowthMetric 
-                    label="PR增长" 
-                    value={growth.prs}
-                    colorClass={getGrowthColor(growth.prs)}
-                    bgClass={getGrowthBgColor(growth.prs)}
-                />
-                <GrowthMetric 
-                    label="Issue 增长"
-                    value={growth.issues}
-                    colorClass={getGrowthColor(growth.issues)}
-                    bgClass={getGrowthBgColor(growth.issues)}
-                />
-                <GrowthMetric 
-                    label="Commit 增长"
-                    value={growth.commits}
-                    colorClass={getGrowthColor(growth.commits)}
-                    bgClass={getGrowthBgColor(growth.commits)}
-                />
-                <GrowthMetric 
-                    label="新增代码" 
-                    value={growth.lines_added}
-                    colorClass={getGrowthColor(growth.lines_added)}
-                    bgClass={getGrowthBgColor(growth.lines_added)}
-                />
-                <GrowthMetric 
-                    label="删除代码" 
-                    value={growth.lines_deleted}
-                    colorClass={getGrowthColor(growth.lines_deleted)}
-                    bgClass={getGrowthBgColor(growth.lines_deleted)}
-                />
-            </div>
+
+            {comparisonAvailable ? (
+                <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+                    <GrowthMetric
+                        label="PR增长"
+                        value={growth.prs}
+                        colorClass={getGrowthColor(growth.prs)}
+                        bgClass={getGrowthBgColor(growth.prs)}
+                    />
+                    <GrowthMetric
+                        label="Issue 增长"
+                        value={growth.issues}
+                        colorClass={getGrowthColor(growth.issues)}
+                        bgClass={getGrowthBgColor(growth.issues)}
+                    />
+                    <GrowthMetric
+                        label="Commit 增长"
+                        value={growth.commits}
+                        colorClass={getGrowthColor(growth.commits)}
+                        bgClass={getGrowthBgColor(growth.commits)}
+                    />
+                    <GrowthMetric
+                        label="新增代码"
+                        value={growth.lines_added}
+                        colorClass={getGrowthColor(growth.lines_added)}
+                        bgClass={getGrowthBgColor(growth.lines_added)}
+                    />
+                    <GrowthMetric
+                        label="删除代码"
+                        value={growth.lines_deleted}
+                        colorClass={getGrowthColor(growth.lines_deleted)}
+                        bgClass={getGrowthBgColor(growth.lines_deleted)}
+                    />
+                </div>
+            ) : (
+                <p className="mt-4 rounded-lg border border-gray-700 bg-gray-900/40 px-4 py-3 text-sm text-gray-400">
+                    {growthData.comparison_unavailable_reason === 'unbounded_range'
+                        ? '全部时间范围不提供环比，请选择具体时间范围。'
+                        : '暂无足够数据进行周期对比。'}
+                </p>
+            )}
         </div>
     );
 };
@@ -104,7 +116,7 @@ const PeriodCard = ({ title, period, highlight }) => {
         }`}>
             <h3 className="text-sm font-semibold mb-2 text-gray-300">{title}</h3>
             <p className="text-xs text-gray-400 mb-3">
-                {start} 至 {end}
+                {start && end ? `${start} 至 ${end}` : '暂无数据'}
             </p>
             <div className="space-y-1.5">
                 <MetricRow label="PR" value={metrics.new_prs} />


### PR DESCRIPTION
## Summary

- anchor organization and SIG growth periods to the latest complete organization snapshot
- use adjacent equal-length windows for bounded ranges
- disable period-over-period growth for the unbounded all-time range
- keep the current all-time totals visible and make PDF export handle the missing previous period

## Validation

- backend: npm test (58 passed)
- frontend: npm run build
- frontend: npx eslint src/components/GrowthReport.jsx
- git diff --check
- Codex review against origin/main: no actionable findings

Full frontend lint still reports pre-existing errors outside the files changed here.

Refs #60