### PR TITLE
fix: resolve frontend ESLint errors and hook warnings

### DIFF
--- a/frontend/src/components/ContributorDetailModal.jsx
+++ b/frontend/src/components/ContributorDetailModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { getContributorDetails } from '../services/api';
 
 const ContributorDetailModal = ({ username, range, onClose }) => {
@@ -6,13 +6,7 @@ const ContributorDetailModal = ({ username, range, onClose }) => {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
 
-    useEffect(() => {
-        if (username) {
-            fetchDetails();
-        }
-    }, [username, range]);
-
-    const fetchDetails = async () => {
+    const fetchDetails = useCallback(async () => {
         setLoading(true);
         setError(null);
         try {
@@ -24,7 +18,13 @@ const ContributorDetailModal = ({ username, range, onClose }) => {
         } finally {
             setLoading(false);
         }
-    };
+    }, [username, range]);
+
+    useEffect(() => {
+        if (username) {
+            fetchDetails();
+        }
+    }, [username, fetchDetails]);
 
     // Handle escape key
     useEffect(() => {

--- a/frontend/src/components/ContributorLeaderboard.jsx
+++ b/frontend/src/components/ContributorLeaderboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { getContributorLeaderboard } from '../services/api';
 import ContributorDetailModal from './ContributorDetailModal';
 
@@ -8,11 +8,7 @@ const ContributorLeaderboard = ({ range = '30d' }) => {
     const [metric, setMetric] = useState('total');
     const [selectedContributor, setSelectedContributor] = useState(null);
 
-    useEffect(() => {
-        fetchLeaderboard();
-    }, [range, metric]);
-
-    const fetchLeaderboard = async () => {
+    const fetchLeaderboard = useCallback(async () => {
         setLoading(true);
         try {
             const data = await getContributorLeaderboard(range, metric, 20);
@@ -22,7 +18,11 @@ const ContributorLeaderboard = ({ range = '30d' }) => {
         } finally {
             setLoading(false);
         }
-    };
+    }, [range, metric]);
+
+    useEffect(() => {
+        fetchLeaderboard();
+    }, [fetchLeaderboard]);
 
     const metrics = [
         { value: 'total', label: '总活动', icon: '🏆', key: 'total_activities', color: 'text-blue-400' },

--- a/frontend/src/components/ContributorStats.jsx
+++ b/frontend/src/components/ContributorStats.jsx
@@ -1,15 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { getContributorStats } from '../services/api';
 
 const ContributorStats = ({ range = '30d' }) => {
     const [stats, setStats] = useState(null);
     const [loading, setLoading] = useState(true);
 
-    useEffect(() => {
-        fetchStats();
-    }, [range]);
-
-    const fetchStats = async () => {
+    const fetchStats = useCallback(async () => {
         setLoading(true);
         try {
             const data = await getContributorStats(range);
@@ -19,7 +15,11 @@ const ContributorStats = ({ range = '30d' }) => {
         } finally {
             setLoading(false);
         }
-    };
+    }, [range]);
+
+    useEffect(() => {
+        fetchStats();
+    }, [fetchStats]);
 
     if (loading) {
         return (
@@ -99,4 +99,3 @@ const StatCard = ({ title, value, icon, color, subtitle }) => {
 };
 
 export default ContributorStats;
-

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
     getOrgSummary,
     getAggregatedTimeseries,
@@ -19,7 +19,8 @@ import ContributorStats from './ContributorStats';
 import DayDetailModal from './DayDetailModal';
 import SIGContributorModal from './SIGContributorModal';
 import RepositoryInsights from './RepositoryInsights';
-import { useToast, ToastContainer } from './Toast';
+import { ToastContainer } from './Toast';
+import { useToast } from '../hooks/useToast';
 
 const Dashboard = () => {
     const [loading, setLoading] = useState(true);
@@ -49,17 +50,19 @@ const Dashboard = () => {
         { key: 'commits', label: 'Commit', name: 'Commit', color: '#10b981' }
     ];
 
-    useEffect(() => {
-        fetchAllData();
-    }, [range, granularity]);
-
-    useEffect(() => {
-        if (selectedSigIds.length > 0) {
-            fetchComparisonData();
+    const fetchGrowthData = useCallback(async () => {
+        setGrowthLoading(true);
+        try {
+            const growth = await getGrowthAnalysis('org', null, range);
+            setGrowthData(growth);
+        } catch (error) {
+            console.error("Failed to load growth data", error);
+        } finally {
+            setGrowthLoading(false);
         }
-    }, [selectedSigIds, range, granularity]);
+    }, [range]);
 
-    const fetchAllData = async () => {
+    const fetchAllData = useCallback(async () => {
         setLoading(true);
         try {
             // 1. Fetch Org Summary, Aggregated Timeseries, and SIGs
@@ -121,21 +124,9 @@ const Dashboard = () => {
         } finally {
             setLoading(false);
         }
-    };
+    }, [range, granularity, fetchGrowthData, addToast]);
 
-    const fetchGrowthData = async () => {
-        setGrowthLoading(true);
-        try {
-            const growth = await getGrowthAnalysis('org', null, range);
-            setGrowthData(growth);
-        } catch (error) {
-            console.error("Failed to load growth data", error);
-        } finally {
-            setGrowthLoading(false);
-        }
-    };
-
-    const fetchComparisonData = async () => {
+    const fetchComparisonData = useCallback(async () => {
         try {
             const data = await compareSigs(selectedSigIds, range, granularity);
             setComparisonData(data);
@@ -143,7 +134,17 @@ const Dashboard = () => {
             console.error("Failed to load comparison data", error);
             addToast('对比数据加载失败', 'error');
         }
-    };
+    }, [selectedSigIds, range, granularity, addToast]);
+
+    useEffect(() => {
+        fetchAllData();
+    }, [fetchAllData]);
+
+    useEffect(() => {
+        if (selectedSigIds.length > 0) {
+            fetchComparisonData();
+        }
+    }, [selectedSigIds, fetchComparisonData]);
 
     const handleRefresh = () => {
         addToast('正在刷新数据...', 'info', 1000);
@@ -347,9 +348,6 @@ const Dashboard = () => {
                     <MultiSIGComparisonChart
                         sigs={comparisonData}
                         selectedSigIds={selectedSigIds}
-                        onSigSelectionChange={setSelectedSigIds}
-                        range={range}
-                        granularity={granularity}
                     />
                 </div>
             </div>

--- a/frontend/src/components/DayDetailModal.jsx
+++ b/frontend/src/components/DayDetailModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { getDayDetails } from '../services/api';
 
 const DayDetailModal = ({ date, chartType = 'prs', onClose }) => {
@@ -7,13 +7,7 @@ const DayDetailModal = ({ date, chartType = 'prs', onClose }) => {
     const [error, setError] = useState(null);
     const [activeTab, setActiveTab] = useState(chartType === 'commits' ? 'commits' : 'prs');
 
-    useEffect(() => {
-        if (date) {
-            fetchDetails();
-        }
-    }, [date]);
-
-    const fetchDetails = async () => {
+    const fetchDetails = useCallback(async () => {
         setLoading(true);
         setError(null);
         try {
@@ -25,7 +19,13 @@ const DayDetailModal = ({ date, chartType = 'prs', onClose }) => {
         } finally {
             setLoading(false);
         }
-    };
+    }, [date]);
+
+    useEffect(() => {
+        if (date) {
+            fetchDetails();
+        }
+    }, [date, fetchDetails]);
 
     // Handle escape key
     useEffect(() => {

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -7,12 +7,12 @@ class ErrorBoundary extends React.Component {
     }
 
     static getDerivedStateFromError(error) {
-        return { hasError: true };
+        return { hasError: true, error };
     }
 
     componentDidCatch(error, errorInfo) {
         console.error('Error caught by boundary:', error, errorInfo);
-        this.state = { hasError: true, error, errorInfo };
+        this.setState({ hasError: true, error, errorInfo });
     }
 
     render() {
@@ -55,4 +55,3 @@ class ErrorBoundary extends React.Component {
 }
 
 export default ErrorBoundary;
-

--- a/frontend/src/components/ExportMenu.jsx
+++ b/frontend/src/components/ExportMenu.jsx
@@ -4,7 +4,6 @@ import api from '../services/api';
 const ExportMenu = ({ type = 'org', range = '30d', sigIds = [], granularity = 'day', summary = {}, growthData = {}, sigData = [], contributors = [], timeseries = [] }) => {
     const [isOpen, setIsOpen] = useState(false);
     const [exporting, setExporting] = useState(false);
-    const [exportingFormat, setExportingFormat] = useState(null);
 
     const downloadFile = (blob, filename) => {
         const url = window.URL.createObjectURL(blob);
@@ -20,7 +19,6 @@ const ExportMenu = ({ type = 'org', range = '30d', sigIds = [], granularity = 'd
 
     const handleExport = async (format) => {
         setExporting(true);
-        setExportingFormat(format);
 
         try {
             if (format === 'csv') {
@@ -83,7 +81,6 @@ const ExportMenu = ({ type = 'org', range = '30d', sigIds = [], granularity = 'd
             alert('导出失败：' + (error.response?.data?.error || error.message));
         } finally {
             setExporting(false);
-            setExportingFormat(null);
         }
     };
 
@@ -161,4 +158,3 @@ const ExportMenu = ({ type = 'org', range = '30d', sigIds = [], granularity = 'd
 };
 
 export default ExportMenu;
-

--- a/frontend/src/components/MultiSIGComparisonChart.jsx
+++ b/frontend/src/components/MultiSIGComparisonChart.jsx
@@ -3,7 +3,7 @@ import ReactECharts from 'echarts-for-react';
 
 const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4', '#84cc16'];
 
-const MultiSIGComparisonChart = ({ sigs, selectedSigIds, onSigSelectionChange, metric = 'new_prs', range, granularity }) => {
+const MultiSIGComparisonChart = ({ sigs, selectedSigIds, metric = 'new_prs' }) => {
     const [chartData, setChartData] = useState([]);
 
     useEffect(() => {

--- a/frontend/src/components/SIGContributorModal.jsx
+++ b/frontend/src/components/SIGContributorModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { getSigContributors } from '../services/api';
 
 const SIGContributorModal = ({ sigId, sigName, range = '30d', onClose }) => {
@@ -6,13 +6,7 @@ const SIGContributorModal = ({ sigId, sigName, range = '30d', onClose }) => {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
 
-    useEffect(() => {
-        if (sigId) {
-            fetchContributors();
-        }
-    }, [sigId, range]);
-
-    const fetchContributors = async () => {
+    const fetchContributors = useCallback(async () => {
         setLoading(true);
         setError(null);
         try {
@@ -24,7 +18,13 @@ const SIGContributorModal = ({ sigId, sigName, range = '30d', onClose }) => {
         } finally {
             setLoading(false);
         }
-    };
+    }, [sigId, range]);
+
+    useEffect(() => {
+        if (sigId) {
+            fetchContributors();
+        }
+    }, [sigId, fetchContributors]);
 
     // Handle escape key
     useEffect(() => {

--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -79,21 +79,4 @@ export const ToastContainer = ({ toasts, removeToast }) => {
     );
 };
 
-// Custom hook for managing toasts
-export const useToast = () => {
-    const [toasts, setToasts] = React.useState([]);
-
-    const addToast = (message, type = 'success', duration = 3000) => {
-        const id = Date.now();
-        setToasts(prev => [...prev, { id, message, type, duration }]);
-    };
-
-    const removeToast = (id) => {
-        setToasts(prev => prev.filter(toast => toast.id !== id));
-    };
-
-    return { toasts, addToast, removeToast };
-};
-
 export default Toast;
-

--- a/frontend/src/hooks/useToast.js
+++ b/frontend/src/hooks/useToast.js
@@ -1,0 +1,17 @@
+import { useCallback, useRef, useState } from 'react';
+
+export const useToast = () => {
+    const [toasts, setToasts] = useState([]);
+    const nextId = useRef(0);
+
+    const addToast = useCallback((message, type = 'success', duration = 3000) => {
+        const id = nextId.current++;
+        setToasts(prev => [...prev, { id, message, type, duration }]);
+    }, []);
+
+    const removeToast = useCallback((id) => {
+        setToasts(prev => prev.filter(toast => toast.id !== id));
+    }, []);
+
+    return { toasts, addToast, removeToast };
+};


### PR DESCRIPTION
修复前端全量 ESLint 的 6 个错误和 7 个 Hook 依赖警告。

为数据请求函数补齐 useCallback 及 Effect 依赖，并稳定 Toast 回调，避免因函数引用变化重复请求。将 useToast 拆分到独立 Hook 文件，清理未使用的导出状态和图表参数，并修正错误边界的状态更新。

验证：
- `npm run lint -- --max-warnings 0`：0 错误、0 警告。
- `npm run build`：通过。
- `git diff --check`：通过。
