### PR TITLE
chore: require Node.js 20 or newer

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,9 @@
         "pdfkit": "^0.17.2",
         "pg": "^8.11.5",
         "redis": "^4.6.13"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@fast-csv/format": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,9 @@
     "test": "node --test",
     "sync-repository-sigs": "node sync_repository_sigs.js --flush-cache"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "keywords": [
     "node",
     "express",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,7 +30,7 @@
         "vite": "^7.1.7"
       },
       "engines": {
-        "node": ">=20"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,9 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.17",
         "vite": "^7.1.7"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "engines": {
-    "node": ">=20"
+    "node": "^20.19.0 || >=22.12.0"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.17",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,9 @@
     "lint": "eslint .",
     "preview": "vite preview"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.17",
     "axios": "^1.12.2",


### PR DESCRIPTION
## Summary

- declare Node.js 20+ support in the frontend and backend packages
- synchronize the corresponding package-lock metadata
- keep all dependency versions unchanged

## Testing

- `cd backend && npm ci`
- `cd backend && npm test` — 52 tests passed
- `cd frontend && npm ci`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

Closes #39