### PR TITLE
test(backend): cover contributor bot filtering

### DIFF
--- a/backend/test/contributor_filters.test.js
+++ b/backend/test/contributor_filters.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    BOT_CONTRIBUTOR_USERNAMES,
+    buildHumanContributorSqlCondition,
+    filterBotContributors,
+    isBotContributor,
+} = require('../contributor_filters');
+
+test('treats ordinary and empty usernames as human contributors', () => {
+    for (const username of ['alice', 'octocat', '', '   ', null, undefined]) {
+        assert.equal(isBotContributor(username), false, `expected ${String(username)} to be human`);
+    }
+});
+
+test('normalizes username casing and surrounding whitespace', () => {
+    assert.equal(isBotContributor('  Dependabot  '), true);
+    assert.equal(isBotContributor('GITHUB-ACTIONS'), true);
+    assert.equal(isBotContributor('  Alice  '), false);
+});
+
+test('recognizes arbitrary usernames with the bot suffix', () => {
+    for (const username of ['release[bot]', 'CUSTOM-AUTOMATION[BOT]', '  helper[bot]  ']) {
+        assert.equal(isBotContributor(username), true, `expected ${username} to be a bot`);
+    }
+});
+
+test('recognizes known bot usernames without the bot suffix', () => {
+    for (const username of ['dependabot', 'dependabot-preview', 'github-actions', 'renovate', 'copilot-swe-agent']) {
+        assert.equal(isBotContributor(username), true, `expected ${username} to be a known bot`);
+    }
+});
+
+test('filters bots while preserving human contributor order and objects', () => {
+    const alice = { username: 'alice', contributions: 5 };
+    const bob = { username: 'bob', contributions: 3 };
+    const contributors = [
+        alice,
+        { username: 'dependabot', contributions: 20 },
+        { username: 'release[bot]', contributions: 10 },
+        bob,
+    ];
+
+    assert.deepEqual(filterBotContributors(contributors), [alice, bob]);
+});
+
+test('builds the SQL conditions used to exclude bot contributors', () => {
+    const condition = buildHumanContributorSqlCondition();
+
+    assert.match(condition, /^LOWER\(c\.github_username\) NOT LIKE '%\[bot\]'/);
+    assert.match(condition, /LOWER\(c\.github_username\) NOT IN \(/);
+    for (const username of BOT_CONTRIBUTOR_USERNAMES) {
+        assert.match(condition, new RegExp(`'${username.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
+    }
+
+    const customCondition = buildHumanContributorSqlCondition('author.login');
+    assert.match(customCondition, /^LOWER\(author\.login\) NOT LIKE '%\[bot\]'/);
+    assert.match(customCondition, /LOWER\(author\.login\) NOT IN \(/);
+});

--- a/backend/test/contributor_filters.test.js
+++ b/backend/test/contributor_filters.test.js
@@ -42,19 +42,27 @@ test('filters bots while preserving human contributor order and objects', () => 
         bob,
     ];
 
-    assert.deepEqual(filterBotContributors(contributors), [alice, bob]);
+    const filteredContributors = filterBotContributors(contributors);
+
+    assert.deepEqual(filteredContributors, [alice, bob]);
+    assert.strictEqual(filteredContributors[0], alice);
+    assert.strictEqual(filteredContributors[1], bob);
 });
 
 test('builds the SQL conditions used to exclude bot contributors', () => {
     const condition = buildHumanContributorSqlCondition();
+    const botUsernameLiterals = BOT_CONTRIBUTOR_USERNAMES
+        .map((username) => `'${username.replace(/'/g, "''")}'`)
+        .join(', ');
 
-    assert.match(condition, /^LOWER\(c\.github_username\) NOT LIKE '%\[bot\]'/);
-    assert.match(condition, /LOWER\(c\.github_username\) NOT IN \(/);
-    for (const username of BOT_CONTRIBUTOR_USERNAMES) {
-        assert.match(condition, new RegExp(`'${username.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
-    }
+    assert.equal(
+        condition,
+        `LOWER(c.github_username) NOT LIKE '%[bot]' AND LOWER(c.github_username) NOT IN (${botUsernameLiterals})`,
+    );
 
     const customCondition = buildHumanContributorSqlCondition('author.login');
-    assert.match(customCondition, /^LOWER\(author\.login\) NOT LIKE '%\[bot\]'/);
-    assert.match(customCondition, /LOWER\(author\.login\) NOT IN \(/);
+    assert.equal(
+        customCondition,
+        `LOWER(author.login) NOT LIKE '%[bot]' AND LOWER(author.login) NOT IN (${botUsernameLiterals})`,
+    );
 });


### PR DESCRIPTION
`contributor_filters.js` centralizes bot detection and filtering, but its behavior had no focused regression coverage. This PR adds isolated `node:test` cases for:

- ordinary, empty, mixed-case, and whitespace-padded usernames;
- arbitrary `[bot]` suffixes and known bot names without that suffix;
- contributor filtering while preserving human order and object identity;
- the default and custom-column SQL conditions used to exclude bots.

The tests do not access PostgreSQL, Redis, GitHub, or the network.

## Validation

- `cd backend && npm test` — 58 tests passed

Closes #32