### PR TITLE
docs: complete backend API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker compose exec backend node run_graphql_backfill.js 30
 | [快速开始](docs/getting-started.md) | Docker Compose、本机开发和数据库初始化 |
 | [界面导览](docs/screenshots.md) | 组织概览、趋势、仓库洞察和贡献者界面 |
 | [架构与数据口径](docs/architecture.md) | 技术栈、数据链路、仓库归属和统计规则 |
-| [API 参考](docs/api.md) | 组织、SIG、仓库、贡献者和导出接口 |
+| [API 参考](docs/api.md) | 按核心数据、分析、贡献者、详情和导出分类的完整接口与参数 |
 | [运行与维护](docs/operations.md) | 迁移、回填、重聚合、缓存和故障排查 |
 
 ## 开发验证

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,23 +4,28 @@
 
 后端默认监听 `http://localhost:3000`。通过 Docker Compose 的前端入口访问时，`/api` 会由 Nginx 代理，例如 `http://localhost:8080/api/v1/organization/summary`。
 
-## 通用参数
+## 常用参数
 
-多数统计接口支持 `range` 查询参数：
+| 参数 | 适用范围 | 说明 |
+|------|----------|------|
+| `range` | 多数统计接口 | 时间范围，默认 `30d`。可传 `7d`、`30d`、`90d` 等 `<days>d` 格式；部分接口支持 `all` |
+| `granularity` | 聚合趋势、SIG 对比、CSV/Excel 导出 | 时间粒度，可选 `day`、`week`、`month`，默认 `day` |
+| `sigIds` | SIG 对比、CSV/Excel 导出 | 逗号分隔的 SIG 数据库 ID，例如 `1,2` |
+| `metric` | 贡献者排行榜 | 排序指标，可选 `total`、`prs`、`issues`、`commits`，默认 `total` |
+| `limit` | 贡献者排行榜 | 返回的贡献者数量，默认 `50` |
+| `type` | 最新活动、导出 | 最新活动使用 `prs|issues`；不同导出格式支持的取值见导出接口说明 |
+| `page`、`per_page` | 最新活动 | 页码默认 `1`，每页数量默认 `10`，`per_page` 最大为 `100` |
 
-- `range=7d`、`range=30d`、`range=90d`：最近 N 天。
-- `range=all`：全部历史数据，仅适用于下文列出的接口。
-
-当前实现中，`all` 可用于组织汇总、仓库和基础时间序列，以及 SIG Commit/API/聚合时间序列、贡献者和 SIG 对比接口。组织聚合时间序列、SIG `summary`、SIG 基础 `timeseries`、增长分析以及 CSV/Excel 导出应传 `<days>d`，否则不能得到“全部历史”语义。
-
-聚合趋势、SIG 对比和导出接口还可使用 `granularity=day|week|month` 控制时间粒度。
+`range=all` 仅适用于下文明确支持的接口。当前实现中，它可用于组织汇总、仓库和基础时间序列，以及 SIG Commit/API/聚合时间序列、贡献者和 SIG 对比接口。组织聚合时间序列、SIG `summary`、SIG 基础 `timeseries`、增长分析以及 CSV/Excel 导出应传 `<days>d`，否则不能得到“全部历史”语义。
 
 ```bash
 curl 'http://localhost:3000/api/v1/organization/summary?range=30d'
 curl 'http://localhost:3000/api/v1/organization/timeseries/aggregated?range=90d&granularity=week'
 ```
 
-## 组织接口
+## 核心数据接口
+
+### 组织数据
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
@@ -28,17 +33,11 @@ curl 'http://localhost:3000/api/v1/organization/timeseries/aggregated?range=90d&
 | GET | `/api/v1/organization/sigs` | SIG 的 ID 和名称列表 |
 | GET | `/api/v1/organization/repositories` | 组织内仓库级指标 |
 | GET | `/api/v1/organization/timeseries` | 组织活动日时间序列 |
-| GET | `/api/v1/organization/timeseries/aggregated` | 按日、周或月聚合的组织活动时间序列 |
-| GET | `/api/v1/organization/latest-activity` | GitHub 上最新的开放 PR 或 Issue |
-| GET | `/api/v1/organization/growth-analysis` | 当前区间与前一区间的增长对比 |
-| GET | `/api/v1/organization/day/:date` | 指定日期的组织活动明细 |
 
 示例：
 
 ```bash
 curl 'http://localhost:3000/api/v1/organization/repositories?range=30d'
-curl 'http://localhost:3000/api/v1/organization/day/2026-09-01'
-curl 'http://localhost:3000/api/v1/organization/latest-activity?type=prs&page=1&per_page=10'
 ```
 
 组织汇总中的新鲜度字段示例：
@@ -52,9 +51,7 @@ curl 'http://localhost:3000/api/v1/organization/latest-activity?type=prs&page=1&
 
 从未成功完成定时采集时，`last_updated_at` 可能为 `null`，且 `data_status` 为 `missing`。
 
-`latest-activity` 的 `type` 必须是 `prs` 或 `issues`；`per_page` 最大为 100。
-
-## SIG 接口
+### SIG 数据
 
 路径中的 `:sigId` 是 `/api/v1/organization/sigs` 返回的数据库 ID，不是 SIG 名称。
 
@@ -64,14 +61,23 @@ curl 'http://localhost:3000/api/v1/organization/latest-activity?type=prs&page=1&
 | GET | `/api/v1/sig/:sigId/timeseries` | SIG 活动日时间序列 |
 | GET | `/api/v1/sig/:sigId/timeseries/commits` | SIG Commit 与代码行时间序列 |
 | GET | `/api/v1/sig/:sigId/timeseries/api` | SIG PR、Issue 与贡献者时间序列 |
-| GET | `/api/v1/sig/:sigId/timeseries/aggregated` | 按日、周或月聚合的 SIG 时间序列 |
-| GET | `/api/v1/sig/:sigId/growth-analysis` | SIG 增长对比 |
-| GET | `/api/v1/sig/:sigId/contributors` | SIG 贡献者数据 |
-| GET | `/api/v1/sigs/compare` | 对比 `sigIds` 指定的多个 SIG |
 
 ```bash
 curl 'http://localhost:3000/api/v1/sig/1/summary?range=30d'
-curl 'http://localhost:3000/api/v1/sig/1/contributors?range=all'
+```
+
+## 分析接口
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/api/v1/organization/timeseries/aggregated` | 按日、周或月聚合的组织活动时间序列 |
+| GET | `/api/v1/organization/growth-analysis` | 组织当前区间与前一区间的增长对比 |
+| GET | `/api/v1/sig/:sigId/timeseries/aggregated` | 按日、周或月聚合的 SIG 时间序列 |
+| GET | `/api/v1/sig/:sigId/growth-analysis` | SIG 当前区间与前一区间的增长对比 |
+| GET | `/api/v1/sigs/compare` | 对比 `sigIds` 指定的多个 SIG |
+
+```bash
+curl 'http://localhost:3000/api/v1/organization/timeseries/aggregated?range=90d&granularity=week'
 curl 'http://localhost:3000/api/v1/sigs/compare?sigIds=1,2&range=90d&granularity=week'
 ```
 
@@ -79,17 +85,31 @@ curl 'http://localhost:3000/api/v1/sigs/compare?sigIds=1,2&range=90d&granularity
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| GET | `/api/v1/contributors/leaderboard` | 贡献者排行榜 |
+| GET | `/api/v1/sig/:sigId/contributors` | 指定 SIG 的贡献者数据 |
+| GET | `/api/v1/contributors/leaderboard` | 按 `metric` 排序的贡献者排行榜，返回数量由 `limit` 控制 |
 | GET | `/api/v1/contributors/stats` | 贡献者总数、新贡献者和最活跃日期概览 |
-| GET | `/api/v1/contributors/:username` | 指定贡献者的活动详情 |
 
 ```bash
-curl 'http://localhost:3000/api/v1/contributors/leaderboard?range=30d'
+curl 'http://localhost:3000/api/v1/sig/1/contributors?range=all'
+curl 'http://localhost:3000/api/v1/contributors/leaderboard?range=30d&metric=commits&limit=20'
 curl 'http://localhost:3000/api/v1/contributors/stats?range=30d'
-curl 'http://localhost:3000/api/v1/contributors/octocat?range=all'
 ```
 
 Bot 账号不会进入人类贡献者指标，但 Bot 提交仍计入组织、SIG 和仓库的 Commit 与代码行活动量。
+
+## 详情接口
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/api/v1/organization/latest-activity` | GitHub 上最新的开放 PR 或 Issue；`type` 必须是 `prs` 或 `issues` |
+| GET | `/api/v1/organization/day/:date` | 指定日期的组织活动明细，日期格式为 `YYYY-MM-DD` |
+| GET | `/api/v1/contributors/:username` | 指定 GitHub 用户名对应的贡献者活动详情 |
+
+```bash
+curl 'http://localhost:3000/api/v1/organization/latest-activity?type=prs&page=1&per_page=10'
+curl 'http://localhost:3000/api/v1/organization/day/2026-09-01'
+curl 'http://localhost:3000/api/v1/contributors/octocat?range=all'
+```
 
 ## 导出接口
 


### PR DESCRIPTION
## 修改内容

- 基于最新 main 保持根 README 的精简文档导航
- 按核心数据、分析、贡献者、详情和导出重新组织 API 参考
- 补充 range、granularity、sigIds、metric、limit 等常用参数
- 增加带查询参数的调用示例，并保留 CSV 导出示例

## 验证

- 已将 backend/server.js 中 22 条公开 /api/v1/ 路由与文档逐项比对，无遗漏或多余项
- git diff --check 通过
- Markdown 代码块数量与结构检查通过
- 仅修改文档，未运行代码测试

Closes #42