### PR TITLE
ci(frontend): 添加 lint 与生产构建工作流

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,43 @@
+name: Frontend CI
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-ci.yml'
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-build:
+    name: Frontend Lint and Build (Node.js 20)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Build production bundle
+        run: npm run build


### PR DESCRIPTION
当前仓库尚未自动检查前端 lint 和生产构建。本 PR 新增前端 GitHub Actions 工作流，在前端文件或工作流发生修改时，对 PR 和 `main` 分支推送运行检查。

工作流使用 Node.js 20，在 `frontend/` 中依次执行 `npm ci`、`npm run lint` 和 `npm run build`；保持只读权限，不使用仓库 Secret，并以 `frontend/package-lock.json` 作为 npm 缓存的依赖路径。

Closes #48

## 验证

- 本地 Node.js 20.20.2：`npm ci`、`npm run lint` 和 `npm run build` 均通过。
- actionlint 1.7.12 工作流检查和 diff 空白检查均通过。
- [个人 fork 内的测试 PR](https://github.com/maple-pwn/Open-Source-Dashboard/pull/1) 已触发[在线工作流](https://github.com/maple-pwn/Open-Source-Dashboard/actions/runs/34495660270)，依赖安装、lint、生产构建及缓存保存全部通过，对应提交为 `2aafe7340fa9905955ce6e42fad94b3f00179eab`。

## 备注

在构建的时候发现了一些漏洞报告，提示 Browserslist 数据过旧、部分包体积较大，打算提两个 issue。

`checkout@v4` 和 `setup-node@v4` 沿用现有后端工作流的版本，GitHub 提示其 Action 内部运行时已弃用并自动切换为 Node.js 24；项目安装、lint 和构建实际使用的版本仍为 Node.js 20.20.2。本次在线检查通过，但尚未单独验证 `main` 推送触发。

## AI 辅助说明

Assisted-by: Codex + GPT-6
