### PR TITLE
feat: track RustSBI repositories under R² SIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ npm run build
 
 ## 重要约定
 
-- `osd_sig` 是仓库 SIG 归属的唯一来源；值为 `untracked` 的仓库不参与后续采集和组织/SIG 聚合。
+- 组织内仓库的 SIG 归属来自 `osd_sig`；值为 `untracked` 的仓库不参与后续采集和组织/SIG 聚合。外部仓库在 [`backend/external_repositories.json`](backend/external_repositories.json) 中按 SIG slug 列出完整的 `owner/repo`，同步后计入对应 SIG 和本看板的仓库范围；RustSBI 项目归入 `r2`。
 - Commit 总数与代码行统计来自 GitHub 默认分支历史。Bot 提交属于仓库活动，但 Bot 账号不计入人类贡献者指标。
 - 服务启动时默认不清空 Redis，也不自动回填历史数据；高影响操作需要显式启用。
 - 不要提交 Token、数据库密码、本地 `.env` 或其他凭据。

--- a/backend/external_repositories.json
+++ b/backend/external_repositories.json
@@ -1,0 +1,25 @@
+{
+  "r2": [
+    "rustsbi/rustsbi",
+    "rustsbi/allwinner-hal",
+    "rustsbi/artinchip-hal",
+    "rustsbi/bouffalo-hal",
+    "rustsbi/kendryte-hal",
+    "rustsbi/sophgo-hal",
+    "rustsbi/spacemit-hal",
+    "rustsbi/th1520-hal",
+    "rustsbi/dw-apb-drivers",
+    "rustsbi/uart-rs",
+    "rustsbi/uart-xscale-rs",
+    "rustsbi/sifive-core",
+    "rustsbi/xuantie",
+    "rustsbi/aclint",
+    "rustsbi/clic",
+    "rustsbi/rpmi",
+    "rustsbi/embedded-hal-skills",
+    "rustsbi/010-editor-scripts",
+    "rustsbi/polyglink",
+    "rustsbi/lssbi",
+    "rustsbi/slides"
+  ]
+}

--- a/backend/github_commit_history.js
+++ b/backend/github_commit_history.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const { resolveRepository } = require('./repository_name');
 const { isBotContributor } = require('./contributor_filters');
 const {
     MAX_RATE_LIMIT_RETRIES,
@@ -147,8 +148,7 @@ async function fetchCommitHistoryViaGraphQL(
 
         while (hasNextPage) {
             const data = await graphQLClient(query, {
-                owner: orgName,
-                repo: repoName,
+                ...resolveRepository(repoName, orgName),
                 since: normalizedStartDate.toISOString(),
                 until: endExclusive.toISOString(),
                 cursor,

--- a/backend/repo_api_ingestion.js
+++ b/backend/repo_api_ingestion.js
@@ -1,4 +1,5 @@
 const { isBotContributor } = require('./contributor_filters');
+const { resolveRepository } = require('./repository_name');
 const { persistRepoApiStats: defaultPersistRepoApiStats } = require('./contributor_api_stats');
 
 function recordContributorActivities(contributorStats, items, metric) {
@@ -30,7 +31,8 @@ async function collectAndPersistRepoApiStats({
     snapshotDate,
     persistRepoApiStats = defaultPersistRepoApiStats,
 }) {
-    const repoQuery = `repo:${orgName}/${repoName}`;
+    const { owner, repo } = resolveRepository(repoName, orgName);
+    const repoQuery = `repo:${owner}/${repo}`;
 
     // Keep these requests sequential because GitHub's Search API has a low rate limit
     // and githubRest applies the delay and pagination policy between requests.

--- a/backend/repository_insights.js
+++ b/backend/repository_insights.js
@@ -110,7 +110,9 @@ function mapRepositoryInsightRow(row, organizationName) {
     return {
         id: toInteger(row.id),
         name: row.name,
-        url: `https://github.com/${organizationName}/${encodeURIComponent(row.name)}`,
+        url: `https://github.com/${row.name.includes('/')
+            ? row.name.split('/').map(encodeURIComponent).join('/')
+            : `${organizationName}/${encodeURIComponent(row.name)}`}`,
         sig: {
             id: toInteger(row.sig_id),
             name: row.sig_name,

--- a/backend/repository_name.js
+++ b/backend/repository_name.js
@@ -1,0 +1,9 @@
+// Local repositories retain their short names; external ones use owner/name.
+function resolveRepository(repoName, orgName) {
+    const parts = repoName.split('/');
+    return parts.length === 2
+        ? { owner: parts[0], repo: parts[1] }
+        : { owner: orgName, repo: repoName };
+}
+
+module.exports = { resolveRepository };

--- a/backend/repository_sig_sync.js
+++ b/backend/repository_sig_sync.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const externalRepositories = require('./external_repositories.json');
 
 const DEFAULT_ORG_NAME = 'hust-open-atom-club';
 const DEFAULT_PROPERTY_NAME = 'osd_sig';
@@ -225,6 +226,7 @@ async function fetchRepositorySigAssignments({
     orgName = DEFAULT_ORG_NAME,
     propertyName = DEFAULT_PROPERTY_NAME,
     httpClient = axios,
+    externalRepositorySigs = {},
 }) {
     const headers = githubHeaders(githubToken);
     const encodedOrg = encodeURIComponent(orgName);
@@ -265,6 +267,29 @@ async function fetchRepositorySigAssignments({
         nextUrl = getNextPageUrl(response.headers?.link);
     }
 
+    // Fetch every external identity before validation and database writes.
+    for (const [sigSlug, repositories] of Object.entries(externalRepositorySigs)) {
+        if (!Object.hasOwn(SIG_DEFINITIONS, sigSlug) || !Array.isArray(repositories)) {
+            throw new Error(`Invalid external repository SIG: ${sigSlug}`);
+        }
+        for (const fullName of repositories) {
+            if (typeof fullName !== 'string' || !/^[\w.-]+\/[\w.-]+$/.test(fullName)) {
+                throw new Error(`Invalid external repository name: ${fullName}`);
+            }
+            const response = await httpClient.get(`https://api.github.com/repos/${fullName}`, {
+                headers, timeout: 30000,
+            });
+            const canonicalName = response.data?.full_name;
+            if (typeof canonicalName !== 'string' || !/^[\w.-]+\/[\w.-]+$/.test(canonicalName)) {
+                throw new Error(`GitHub returned an invalid full_name for ${fullName}`);
+            }
+            rows.push({
+                repository_id: response.data.id,
+                repository_name: canonicalName,
+                properties: [{ property_name: propertyName, value: sigSlug }],
+            });
+        }
+    }
     return normalizeAssignments(rows, propertyName);
 }
 
@@ -590,12 +615,14 @@ async function syncRepositorySigsFromGitHub({
     orgName = DEFAULT_ORG_NAME,
     propertyName = DEFAULT_PROPERTY_NAME,
     httpClient = axios,
+    externalRepositorySigs = orgName === DEFAULT_ORG_NAME ? externalRepositories : {},
 }) {
     const assignments = await fetchRepositorySigAssignments({
         githubToken,
         orgName,
         propertyName,
         httpClient,
+        externalRepositorySigs,
     });
 
     return applyRepositorySigAssignments({ pool, assignments, orgName });

--- a/backend/run_graphql_backfill.js
+++ b/backend/run_graphql_backfill.js
@@ -40,6 +40,7 @@ const {
 // --- Configuration ---
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const ORG_NAME = 'hust-open-atom-club';
+const { resolveRepository } = require('./repository_name');
 const PROGRESS_FILE = path.join(__dirname, 'backfill_progress.json');
 
 // --- Optimized Concurrency Settings ---
@@ -237,8 +238,7 @@ async function fetchRepoStatsViaGraphQL(repoName, startDate, endDate, graphQLCli
 
         while (!prDone) {
             const data = await graphQLClient(query, {
-                owner: ORG_NAME,
-                repo: repoName,
+                ...resolveRepository(repoName, ORG_NAME),
                 prCursor: prCursor,
                 issueCursor: null,
             });
@@ -323,8 +323,7 @@ async function fetchRepoStatsViaGraphQL(repoName, startDate, endDate, graphQLCli
 
         while (!issueDone) {
             const data = await graphQLClient(query, {
-                owner: ORG_NAME,
-                repo: repoName,
+                ...resolveRepository(repoName, ORG_NAME),
                 prCursor: null,
                 issueCursor: issueCursor,
             });

--- a/backend/server.js
+++ b/backend/server.js
@@ -55,6 +55,7 @@ const PORT = process.env.PORT || 3000;
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_API_BASE = 'https://api.github.com';
 const ORG_NAME = 'hust-open-atom-club';
+const { resolveRepository } = require('./repository_name');
 const HUMAN_CONTRIBUTOR_SQL = buildHumanContributorSqlCondition('c.github_username');
 const TRACKED_CONTRIBUTOR_ACTIVITY_SQL = `EXISTS (
     SELECT 1
@@ -436,8 +437,7 @@ async function fetchRepoStatsViaGraphQL(repoName, startDate, endDate) {
 
         while (!prDone) {
             const data = await githubGraphQL(query, {
-                owner: ORG_NAME,
-                repo: repoName,
+                ...resolveRepository(repoName, ORG_NAME),
                 prCursor: prCursor,
                 issueCursor: null,
             });
@@ -490,8 +490,7 @@ async function fetchRepoStatsViaGraphQL(repoName, startDate, endDate) {
 
         while (!issueDone) {
             const data = await githubGraphQL(query, {
-                owner: ORG_NAME,
-                repo: repoName,
+                ...resolveRepository(repoName, ORG_NAME),
                 prCursor: null,
                 issueCursor: issueCursor,
             });

--- a/backend/test/external_repositories.test.js
+++ b/backend/test/external_repositories.test.js
@@ -1,0 +1,116 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const configured = require('../external_repositories.json');
+const { SIG_DEFINITIONS, syncRepositorySigsFromGitHub } = require('../repository_sig_sync');
+const { resolveRepository } = require('../repository_name');
+const { fetchCommitsViaGraphQL } = require('../github_commit_history');
+const { fetchRepoStatsViaGraphQL } = require('../run_graphql_backfill');
+const { collectAndPersistRepoApiStats } = require('../repo_api_ingestion');
+const { mapRepositoryInsightRow } = require('../repository_insights');
+
+function githubClient(externalGet) {
+    return { async get(url) {
+        if (url.includes('/properties/schema/')) return { data: {
+            property_name: 'osd_sig', value_type: 'single_select',
+            allowed_values: ['untracked', ...Object.keys(SIG_DEFINITIONS)],
+        } };
+        if (url.includes('/properties/values')) return { data: [{
+            repository_id: 1, repository_name: 'rustsbi',
+            properties: [{ property_name: 'osd_sig', value: 'r2' }],
+        }], headers: {} };
+        return externalGet(url);
+    } };
+}
+
+test('external RustSBI repositories join R² alongside the club repository without name collisions', async () => {
+    const inserted = [];
+    const groups = new Map();
+    const fetched = [];
+    const result = await syncRepositorySigsFromGitHub({
+        githubToken: 'test-token',
+        httpClient: githubClient(async url => {
+            const fullName = url.split('/repos/')[1];
+            fetched.push(fullName);
+            return { data: { id: 100 + fetched.length, full_name: fullName } };
+        }),
+        pool: { async connect() { return {
+            async query(sql, params) {
+                if (sql.includes('INSERT INTO organizations')) {
+                    assert.deepEqual(params, ['hust-open-atom-club']);
+                    return { rows: [{ id: 1 }] };
+                }
+                if (sql.includes('INSERT INTO special_interest_groups')) {
+                    groups.set(params[1], groups.size + 1);
+                    return { rows: [{ id: groups.get(params[1]) }] };
+                }
+                if (sql.includes('INSERT INTO repositories')) inserted.push(params);
+                return { rows: [], rowCount: 0 };
+            },
+            release() {},
+        }; } },
+    });
+    assert.deepEqual(fetched, configured.r2);
+    const expectedNames = ['rustsbi', ...configured.r2];
+    assert.equal(result.tracked, expectedNames.length);
+    assert.deepEqual(inserted.map(row => row[3]).sort(), expectedNames.sort());
+    assert.equal(new Set(inserted.map(row => row[3])).size, expectedNames.length);
+    assert.ok(inserted.every(row => row[0] === 1 && row[1] === groups.get('r2')));
+});
+
+test('failed external lookups and duplicate identities abort before database writes', async () => {
+    for (const externalGet of [
+        async () => { throw new Error('lookup failed'); },
+        async () => ({ data: { id: 1, full_name: 'rustsbi/rustsbi' } }),
+    ]) {
+        let connected = false;
+        await assert.rejects(syncRepositorySigsFromGitHub({
+            githubToken: 'test-token',
+            externalRepositorySigs: { r2: ['rustsbi/rustsbi'] },
+            httpClient: githubClient(externalGet),
+            pool: { connect() { connected = true; throw new Error('Unexpected database access'); } },
+        }), /lookup failed|duplicate repository_id/);
+        assert.equal(connected, false);
+    }
+});
+
+test('REST searches use the external owner but persistence retains the dashboard organization', async () => {
+    await collectAndPersistRepoApiStats({
+        orgName: 'hust-open-atom-club', repoName: 'rustsbi/spacemit-hal',
+        repoId: 42, snapshotDate: '2026-09-12',
+        githubRest: async (endpoint, params) => {
+            assert.ok(params.q.startsWith('repo:rustsbi/spacemit-hal '));
+            return { items: [], total_count: 0 };
+        },
+        persistRepoApiStats: async params => {
+            assert.equal(params.orgName, 'hust-open-atom-club');
+            assert.equal(params.repoId, 42);
+            return {};
+        },
+    });
+});
+
+test('commit and PR/issue backfill use external repository coordinates', async () => {
+    const date = new Date('2026-09-12T12:00:00Z');
+    let calls = 0;
+    const client = async (query, variables) => {
+        calls++;
+        assert.equal(variables.owner, 'rustsbi');
+        assert.equal(variables.repo, 'spacemit-hal');
+        return { repository: {
+            defaultBranchRef: null,
+            pullRequests: { nodes: [], pageInfo: { hasNextPage: false } },
+            issues: { nodes: [], pageInfo: { hasNextPage: false } },
+        } };
+    };
+    await fetchCommitsViaGraphQL('rustsbi/spacemit-hal', date, client);
+    await fetchRepoStatsViaGraphQL('rustsbi/spacemit-hal', date, date, client);
+    assert.equal(calls, 3);
+});
+
+test('short repository names keep their owner while external links resolve to RustSBI', () => {
+    assert.deepEqual(resolveRepository('rustsbi', 'hust-open-atom-club'), {
+        owner: 'hust-open-atom-club', repo: 'rustsbi',
+    });
+    assert.equal(mapRepositoryInsightRow({ name: 'rustsbi/spacemit-hal' }, 'hust-open-atom-club').url,
+        'https://github.com/rustsbi/spacemit-hal');
+});


### PR DESCRIPTION
Add rustsbi/rustsbi repositories to the external repository list. Support owner-qualified names in synchronization, ingestion, backfill and repository links.

r? @mudongliang 